### PR TITLE
Add shell environment policy overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,18 @@
      messages-last and messages-count subcommands
 240. MessageHistoryTests cover new APIs
 
+241. Implemented minimal McpClient class for JSON-RPC communication
+242. Added mcp-client command running an MCP server and listing tools
+243. Added JsonToToml utility converting JSON values to TOML
+244. Introduced JsonToTomlTests verifying basic conversion
+245. Provider command now supports 'login' subcommand to store API keys
+246. Program registers new mcp-client command
+247. History messages-last subcommand accepts --json option
+248. Added unit tests for JsonToToml
+249. Created McpClientCommand options for timeout and JSON output
+250. Implemented provider login key saving via ApiKeyManager
+
 ## TODO Next Run
 - Port more Rust CLI features
 - Investigate hanging tests and fix
+- Expand MCP client functionality and add more protocol tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,17 @@
 204. Added ExecEnvTests verifying default excludes are removed
 205. ExecEnvTests verify include_only filtering
 206. Created new test file ExecEnvTests.cs
+207. Added CLI options to override shell environment policy
+208. Created ShellEnvPolicy fields in ExecOptions and InteractiveOptions
+209. Extended ExecBinder and InteractiveBinder to bind env options
+210. ExecCommand and InteractiveCommand apply policy overrides and pass env to NotifyUtils
+211. NotifyUtils accepts environment dictionary
+212. ChatGptLogin accepts environment and LoginCommand uses policy overrides via new binder
+213. DebugCommand supports env policy options for seatbelt/landlock
+214. Added LoginBinder and LoginOptions classes
+215. Updated binder tests for new options
+216. Build and tests updated for .NET 8
 
 ## TODO Next Run
-- Implement shell environment policy overrides via CLI
-- Integrate ExecEnv into other commands that spawn processes
+- Verify new env policy features across all commands
+- Continue migrating remaining Rust features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,8 +278,15 @@
 254. McpClientCommand prints results in JSON format when requested
 255. Added CreateServerEnv helper aligning with Rust defaults
 256. Extended JsonToTomlTests with array conversion
+257. Added project_doc_max_bytes config field with CLI overrides
+258. ProjectDoc.GetUserInstructions now accepts size and path overrides
+259. Exec and interactive commands expose --project-doc-max-bytes and --project-doc-path
+260. Added messages-watch subcommand to history command
+261. Implemented MessageHistory.WatchEntriesAsync API
+262. Added unit tests for project doc limit and message watching
 
 ## TODO Next Run
 - Port more Rust CLI features
 - Investigate hanging tests and fix
 - Expand MCP client functionality and add more protocol tests
+- Implement remaining MCP server features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,11 @@
 221. MockCodexAgent emits TaskStartedEvent
 222. History command gained info subcommand listing sessions with start times
 223. Added AppConfigExtraTests for new config fields
+224. Introduced MarkdownUtils with citation rewriting
+225. EventProcessor rewrites file citations in agent messages
+226. ExecCommand passes file opener to EventProcessor
+227. Added MarkdownUtilsTests verifying citation rewriting
 
 ## TODO Next Run
-- Verify history persistence and task start handling
-- Continue migrating remaining Rust features
+- Verify citation rewriting integration
+- Implement remaining Rust features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,14 @@
 214. Added LoginBinder and LoginOptions classes
 215. Updated binder tests for new options
 216. Build and tests updated for .NET 8
+217. Added HistoryPersistence, UriBasedFileOpener and Tui parsing in AppConfig
+218. SessionManager respects HistoryPersistence setting
+219. Exec and Interactive commands configure SessionManager persistence
+220. Added TaskStartedEvent and EventProcessor handling
+221. MockCodexAgent emits TaskStartedEvent
+222. History command gained info subcommand listing sessions with start times
+223. Added AppConfigExtraTests for new config fields
 
 ## TODO Next Run
-- Verify new env policy features across all commands
+- Verify history persistence and task start handling
 - Continue migrating remaining Rust features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,17 @@
 226. ExecCommand passes file opener to EventProcessor
 227. Added MarkdownUtilsTests verifying citation rewriting
 
+228. Added MessageHistory utility writing global `history.jsonl`
+229. AppendEntryAsync sets owner-only permissions on Unix
+230. Implemented HistoryMetadataAsync and LookupEntry helpers
+231. ExecCommand saves agent messages to message history
+232. ExecCommand saves AddToHistory events to message history
+233. HistoryCommand now has messages-meta and messages-entry subcommands
+234. Added MessageHistoryTests verifying append and lookup
+235. InteractiveCommand toggles mouse capture based on config
+236. HistoryCommand registers new message history subcommands
+237. Installed .NET 8 SDK via apt-get for building
+
 ## TODO Next Run
-- Verify citation rewriting integration
+- Expand message history CLI
 - Implement remaining Rust features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,11 @@
 235. InteractiveCommand toggles mouse capture based on config
 236. HistoryCommand registers new message history subcommands
 237. Installed .NET 8 SDK via apt-get for building
+238. Added MessageHistory API for counting, searching, last-N, and clearing entries
+239. Extended HistoryCommand with messages-path, messages-clear, messages-search,
+     messages-last and messages-count subcommands
+240. MessageHistoryTests cover new APIs
 
 ## TODO Next Run
-- Expand message history CLI
-- Implement remaining Rust features
+- Port more Rust CLI features
+- Investigate hanging tests and fix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,12 @@
 248. Added unit tests for JsonToToml
 249. Created McpClientCommand options for timeout and JSON output
 250. Implemented provider login key saving via ApiKeyManager
+251. Added typed MCP request/response records and default server environment
+252. McpClient now exposes InitializeAsync, ListToolsAsync and CallToolAsync
+253. McpClientCommand supports --call, --args and --env for tool invocation
+254. McpClientCommand prints results in JSON format when requested
+255. Added CreateServerEnv helper aligning with Rust defaults
+256. Extended JsonToTomlTests with array conversion
 
 ## TODO Next Run
 - Port more Rust CLI features

--- a/codex-dotnet/CodexCli.Tests/AppConfigExtraTests.cs
+++ b/codex-dotnet/CodexCli.Tests/AppConfigExtraTests.cs
@@ -1,0 +1,25 @@
+namespace CodexCli.Tests;
+
+using CodexCli.Config;
+using System.IO;
+
+public class AppConfigExtraTests
+{
+    [Fact]
+    public void ParsesHistoryAndFileOpener()
+    {
+        var toml = "file_opener = 'vscode'\n" +
+                    "[history]\n" +
+                    "persistence = 'none'\n" +
+                    "max_bytes = 1024\n" +
+                    "[tui]\n" +
+                    "disable_mouse_capture = true\n";
+        var tmp = Path.GetTempFileName();
+        File.WriteAllText(tmp, toml);
+
+        var cfg = AppConfig.Load(tmp);
+        Assert.Equal(HistoryPersistence.None, cfg.History.Persistence);
+        Assert.Equal(1024, cfg.History.MaxBytes);
+        Assert.True(cfg.Tui.DisableMouseCapture);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/AppConfigExtraTests.cs
+++ b/codex-dotnet/CodexCli.Tests/AppConfigExtraTests.cs
@@ -9,6 +9,7 @@ public class AppConfigExtraTests
     public void ParsesHistoryAndFileOpener()
     {
         var toml = "file_opener = 'vscode'\n" +
+                    "project_doc_max_bytes = 2048\n" +
                     "[history]\n" +
                     "persistence = 'none'\n" +
                     "max_bytes = 1024\n" +
@@ -20,6 +21,7 @@ public class AppConfigExtraTests
         var cfg = AppConfig.Load(tmp);
         Assert.Equal(HistoryPersistence.None, cfg.History.Persistence);
         Assert.Equal(1024, cfg.History.MaxBytes);
+        Assert.Equal(2048, cfg.ProjectDocMaxBytes);
         Assert.True(cfg.Tui.DisableMouseCapture);
     }
 }

--- a/codex-dotnet/CodexCli.Tests/ExecBinderTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ExecBinderTests.cs
@@ -37,11 +37,13 @@ public class ExecBinderTests
         var envExcludeOpt = new Option<string[]>("--env-exclude") { AllowMultipleArgumentsPerToken = true };
         var envSetOpt = new Option<string[]>("--env-set") { AllowMultipleArgumentsPerToken = true };
         var envIncludeOpt = new Option<string[]>("--env-include-only") { AllowMultipleArgumentsPerToken = true };
+        var docMaxOpt = new Option<int?>("--project-doc-max-bytes");
+        var docPathOpt = new Option<string?>("--project-doc-path");
 
         var binder = new ExecBinder(promptArg, imagesOpt, modelOpt, profileOpt, providerOpt,
             fullAutoOpt, approvalOpt, sandboxOpt, colorOpt, cwdOpt, lastOpt, skipGitOpt,
             notifyOpt, overridesOpt, effortOpt, summaryOpt, instrOpt, hideReasonOpt, disableStorageOpt,
-            noProjDocOpt, jsonOpt, logOpt, envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt);
+            noProjDocOpt, jsonOpt, logOpt, envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt, docMaxOpt, docPathOpt);
 
         var cmd = new Command("exec");
         cmd.AddArgument(promptArg);

--- a/codex-dotnet/CodexCli.Tests/InteractiveBinderTests.cs
+++ b/codex-dotnet/CodexCli.Tests/InteractiveBinderTests.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using CodexCli.Commands;
 using System.IO;
+using CodexCli.Config;
 
 namespace CodexCli.Tests;
 
@@ -30,10 +31,16 @@ public class InteractiveBinderTests
         var noProjDocOpt = new Option<bool>("--no-project-doc");
         var lastMsgOpt = new Option<string?>("--output-last-message");
         var logOpt = new Option<string?>("--event-log");
+        var envInheritOpt = new Option<ShellEnvironmentPolicyInherit?>("--env-inherit");
+        var envIgnoreOpt = new Option<bool?>("--env-ignore-default-excludes");
+        var envExcludeOpt = new Option<string[]>("--env-exclude") { AllowMultipleArgumentsPerToken = true };
+        var envSetOpt = new Option<string[]>("--env-set") { AllowMultipleArgumentsPerToken = true };
+        var envIncludeOpt = new Option<string[]>("--env-include-only") { AllowMultipleArgumentsPerToken = true };
 
         var binder = new InteractiveBinder(promptArg, imagesOpt, modelOpt, profileOpt, providerOpt,
             fullAutoOpt, approvalOpt, sandboxOpt, colorOpt, skipGitOpt, cwdOpt, notifyOpt, overridesOpt,
-            effortOpt, summaryOpt, instrOpt, hideReasonOpt, disableStorageOpt, lastMsgOpt, noProjDocOpt, logOpt);
+            effortOpt, summaryOpt, instrOpt, hideReasonOpt, disableStorageOpt, lastMsgOpt, noProjDocOpt, logOpt,
+            envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt);
 
         var cmd = new Command("interactive");
         cmd.AddArgument(promptArg);
@@ -44,12 +51,17 @@ public class InteractiveBinderTests
         cmd.AddOption(noProjDocOpt);
         cmd.AddOption(lastMsgOpt);
         cmd.AddOption(logOpt);
+        cmd.AddOption(envInheritOpt);
+        cmd.AddOption(envIgnoreOpt);
+        cmd.AddOption(envExcludeOpt);
+        cmd.AddOption(envSetOpt);
+        cmd.AddOption(envIncludeOpt);
         InteractiveOptions? captured = null;
         cmd.SetHandler((InteractiveOptions o) => captured = o, binder);
         var root = new RootCommand();
         root.AddCommand(cmd);
 
-        await root.InvokeAsync("interactive hello --full-auto --skip-git-repo-check --hide-agent-reasoning --disable-response-storage --no-project-doc --event-log t.log");
+        await root.InvokeAsync("interactive hello --full-auto --skip-git-repo-check --hide-agent-reasoning --disable-response-storage --no-project-doc --event-log t.log --env-inherit none --env-exclude SECRET --env-set F=2 --env-include-only PATH");
 
         Assert.NotNull(captured);
         Assert.True(captured!.FullAuto);
@@ -59,5 +71,9 @@ public class InteractiveBinderTests
         Assert.True(captured.DisableResponseStorage);
         Assert.True(captured.NoProjectDoc);
         Assert.Equal("t.log", captured.EventLogFile);
+        Assert.Equal(ShellEnvironmentPolicyInherit.None, captured.EnvInherit);
+        Assert.Contains("SECRET", captured.EnvExclude);
+        Assert.Contains("F=2", captured.EnvSet);
+        Assert.Contains("PATH", captured.EnvIncludeOnly);
     }
 }

--- a/codex-dotnet/CodexCli.Tests/InteractiveBinderTests.cs
+++ b/codex-dotnet/CodexCli.Tests/InteractiveBinderTests.cs
@@ -36,11 +36,13 @@ public class InteractiveBinderTests
         var envExcludeOpt = new Option<string[]>("--env-exclude") { AllowMultipleArgumentsPerToken = true };
         var envSetOpt = new Option<string[]>("--env-set") { AllowMultipleArgumentsPerToken = true };
         var envIncludeOpt = new Option<string[]>("--env-include-only") { AllowMultipleArgumentsPerToken = true };
+        var docMaxOpt = new Option<int?>("--project-doc-max-bytes");
+        var docPathOpt = new Option<string?>("--project-doc-path");
 
         var binder = new InteractiveBinder(promptArg, imagesOpt, modelOpt, profileOpt, providerOpt,
             fullAutoOpt, approvalOpt, sandboxOpt, colorOpt, skipGitOpt, cwdOpt, notifyOpt, overridesOpt,
             effortOpt, summaryOpt, instrOpt, hideReasonOpt, disableStorageOpt, lastMsgOpt, noProjDocOpt, logOpt,
-            envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt);
+            envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt, docMaxOpt, docPathOpt);
 
         var cmd = new Command("interactive");
         cmd.AddArgument(promptArg);

--- a/codex-dotnet/CodexCli.Tests/JsonToTomlTests.cs
+++ b/codex-dotnet/CodexCli.Tests/JsonToTomlTests.cs
@@ -12,4 +12,13 @@ public class JsonToTomlTests
         Assert.Contains("a = 1", toml);
         Assert.Contains("b = \"x\"", toml);
     }
+
+    [Fact]
+    public void Convert_Array()
+    {
+        var json = JsonDocument.Parse("[1,2,3]");
+        var toml = JsonToToml.ConvertToToml(json.RootElement);
+        Assert.Contains("0 = 1", toml);
+        Assert.Contains("1 = 2", toml);
+    }
 }

--- a/codex-dotnet/CodexCli.Tests/JsonToTomlTests.cs
+++ b/codex-dotnet/CodexCli.Tests/JsonToTomlTests.cs
@@ -1,0 +1,15 @@
+using CodexCli.Util;
+using System.Text.Json;
+using Xunit;
+
+public class JsonToTomlTests
+{
+    [Fact]
+    public void Convert_Object()
+    {
+        var json = JsonDocument.Parse("{\"a\":1,\"b\":\"x\"}");
+        var toml = JsonToToml.ConvertToToml(json.RootElement);
+        Assert.Contains("a = 1", toml);
+        Assert.Contains("b = \"x\"", toml);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/MarkdownUtilsTests.cs
+++ b/codex-dotnet/CodexCli.Tests/MarkdownUtilsTests.cs
@@ -1,0 +1,45 @@
+using CodexCli.Util;
+using CodexCli.Config;
+using Xunit;
+
+public class MarkdownUtilsTests
+{
+    [Fact]
+    public void CitationIsRewrittenWithAbsolutePath()
+    {
+        var cwd = "/workspace";
+        var md = "See 【F:/src/main.rs†L42-L50】 for details.";
+        var res = MarkdownUtils.RewriteFileCitations(md, UriBasedFileOpener.VsCode, cwd);
+        Assert.Equal("See [/src/main.rs:42](vscode://file/src/main.rs:42)  for details.", res);
+    }
+
+    [Fact]
+    public void CitationIsRewrittenWithRelativePath()
+    {
+        var cwd = "/home/user/project";
+        var md = "Refer to 【F:lib/mod.rs†L5】 here.";
+        var res = MarkdownUtils.RewriteFileCitations(md, UriBasedFileOpener.Windsurf, cwd);
+        Assert.Equal("Refer to [lib/mod.rs:5](windsurf://file/home/user/project/lib/mod.rs:5)  here.", res);
+    }
+
+    [Fact]
+    public void CitationFollowedBySpace()
+    {
+        var cwd = "/home/user/project";
+        var md = "References on lines 【F:src/foo.rs†L24】【F:src/foo.rs†L42】";
+        var res = MarkdownUtils.RewriteFileCitations(md, UriBasedFileOpener.VsCode, cwd);
+        Assert.Equal("References on lines [src/foo.rs:24](vscode://file/home/user/project/src/foo.rs:24) [src/foo.rs:42](vscode://file/home/user/project/src/foo.rs:42) ", res);
+    }
+
+    [Fact]
+    public void CitationUnchangedWithoutOpener()
+    {
+        var cwd = "/";
+        var md = "Look at 【F:file.rs†L1】.";
+        var res = MarkdownUtils.RewriteFileCitations(md, UriBasedFileOpener.VsCode, cwd);
+        // When opener is None, the text should stay the same via append helper, but our helper rewrites always.
+        var rendered = MarkdownUtils.RewriteFileCitations(md, UriBasedFileOpener.None, cwd);
+        Assert.Equal(md, rendered);
+        Assert.NotEqual(md, res);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/MessageHistoryTests.cs
+++ b/codex-dotnet/CodexCli.Tests/MessageHistoryTests.cs
@@ -1,0 +1,21 @@
+using CodexCli.Util;
+using CodexCli.Config;
+using Xunit;
+
+public class MessageHistoryTests
+{
+    [Fact]
+    public async Task AppendAndLookup()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mh" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var cfg = new AppConfig { CodexHome = dir };
+        await MessageHistory.AppendEntryAsync("hello", "s1", cfg);
+        await MessageHistory.AppendEntryAsync("world", "s1", cfg);
+        var meta = await MessageHistory.HistoryMetadataAsync(cfg);
+        Assert.Equal(2, meta.Count);
+        var e1 = MessageHistory.LookupEntry(meta.LogId, 1, cfg);
+        Assert.Equal("world", e1);
+        Directory.Delete(dir, true);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/MessageHistoryTests.cs
+++ b/codex-dotnet/CodexCli.Tests/MessageHistoryTests.cs
@@ -1,5 +1,6 @@
 using CodexCli.Util;
 using CodexCli.Config;
+using System.Linq;
 using Xunit;
 
 public class MessageHistoryTests
@@ -16,6 +17,16 @@ public class MessageHistoryTests
         Assert.Equal(2, meta.Count);
         var e1 = MessageHistory.LookupEntry(meta.LogId, 1, cfg);
         Assert.Equal("world", e1);
+        var count = await MessageHistory.CountEntriesAsync(cfg);
+        Assert.Equal(2, count);
+        var last = await MessageHistory.LastEntriesAsync(1, cfg);
+        Assert.Single(last);
+        Assert.Equal("world", last.First());
+        var search = await MessageHistory.SearchEntriesAsync("hello", cfg);
+        Assert.Single(search);
+        MessageHistory.ClearHistory(cfg);
+        var meta2 = await MessageHistory.HistoryMetadataAsync(cfg);
+        Assert.Equal(0, meta2.Count);
         Directory.Delete(dir, true);
     }
 }

--- a/codex-dotnet/CodexCli.Tests/MessageHistoryWatchTests.cs
+++ b/codex-dotnet/CodexCli.Tests/MessageHistoryWatchTests.cs
@@ -1,0 +1,19 @@
+using CodexCli.Config;
+using CodexCli.Util;
+
+public class MessageHistoryWatchTests
+{
+    [Fact]
+    public async Task WatchYieldsNewEntries()
+    {
+        var cfg = new AppConfig();
+        cfg.CodexHome = Path.GetTempPath();
+        MessageHistory.ClearHistory(cfg);
+        var cts = new CancellationTokenSource();
+        var enumerator = MessageHistory.WatchEntriesAsync(cfg, cts.Token).GetAsyncEnumerator();
+        await MessageHistory.AppendEntryAsync("one", "s1", cfg);
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("one", enumerator.Current);
+        cts.Cancel();
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/ProjectDocLimitTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ProjectDocLimitTests.cs
@@ -1,0 +1,20 @@
+using CodexCli.Config;
+using CodexCli.Util;
+
+public class ProjectDocLimitTests
+{
+    [Fact]
+    public void TruncatesProjectDoc()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        var docPath = Path.Combine(dir, "AGENTS.md");
+        var content = new string('a', 2000);
+        File.WriteAllText(docPath, content);
+        var cfgPath = Path.Combine(dir, "config.toml");
+        File.WriteAllText(cfgPath, "project_doc_max_bytes = 1000");
+        var cfg = AppConfig.Load(cfgPath);
+        var inst = ProjectDoc.GetUserInstructions(cfg, dir, false, null, null);
+        Assert.True(inst!.Length <= 1000);
+    }
+}

--- a/codex-dotnet/CodexCli/Commands/DebugCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/DebugCommand.cs
@@ -9,31 +9,47 @@ public static class DebugCommand
     public static Command Create(Option<string?> configOption, Option<string?> cdOption)
     {
         var cmd = new Command("debug", "Debug commands");
+        var envInheritOpt = new Option<ShellEnvironmentPolicyInherit?>("--env-inherit");
+        var envIgnoreOpt = new Option<bool?>("--env-ignore-default-excludes");
+        var envExcludeOpt = new Option<string[]>("--env-exclude") { AllowMultipleArgumentsPerToken = true };
+        var envSetOpt = new Option<string[]>("--env-set") { AllowMultipleArgumentsPerToken = true };
+        var envIncludeOpt = new Option<string[]>("--env-include-only") { AllowMultipleArgumentsPerToken = true };
 
         var seatbeltArg = new Argument<string>("cmd");
         var seatbelt = new Command("seatbelt", "Run command under seatbelt");
         seatbelt.AddArgument(seatbeltArg);
-        seatbelt.SetHandler((string c, string? cfgPath, string? cd) =>
+        seatbelt.AddOption(envInheritOpt);
+        seatbelt.AddOption(envIgnoreOpt);
+        seatbelt.AddOption(envExcludeOpt);
+        seatbelt.AddOption(envSetOpt);
+        seatbelt.AddOption(envIncludeOpt);
+        seatbelt.SetHandler((string c, string? cfgPath, string? cd, ShellEnvironmentPolicyInherit? inh, bool? ign, string[] exc, string[] set, string[] inc) =>
         {
             if (cd != null) Environment.CurrentDirectory = cd;
-            RunProcess(c, cfgPath);
-        }, seatbeltArg, configOption, cdOption);
+            RunProcess(c, cfgPath, inh, ign, exc, set, inc);
+        }, seatbeltArg, configOption, cdOption, envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt);
 
         var landlockArg = new Argument<string>("cmd");
         var landlock = new Command("landlock", "Run command under landlock");
         landlock.AddArgument(landlockArg);
-        landlock.SetHandler((string c, string? cfgPath, string? cd) =>
+        landlock.AddOption(envInheritOpt);
+        landlock.AddOption(envIgnoreOpt);
+        landlock.AddOption(envExcludeOpt);
+        landlock.AddOption(envSetOpt);
+        landlock.AddOption(envIncludeOpt);
+        landlock.SetHandler((string c, string? cfgPath, string? cd, ShellEnvironmentPolicyInherit? inh, bool? ign, string[] exc, string[] set, string[] inc) =>
         {
             if (cd != null) Environment.CurrentDirectory = cd;
-            RunProcess(c, cfgPath);
-        }, landlockArg, configOption, cdOption);
+            RunProcess(c, cfgPath, inh, ign, exc, set, inc);
+        }, landlockArg, configOption, cdOption, envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt);
 
         cmd.AddCommand(seatbelt);
         cmd.AddCommand(landlock);
         return cmd;
     }
 
-    private static void RunProcess(string command, string? configPath)
+    private static void RunProcess(string command, string? configPath,
+        ShellEnvironmentPolicyInherit? inh, bool? ign, string[] exc, string[] set, string[] inc)
     {
         var parts = command.Split(' ', 2);
         var psi = new System.Diagnostics.ProcessStartInfo(parts[0])
@@ -45,7 +61,13 @@ public static class DebugCommand
         if (!string.IsNullOrEmpty(configPath) && File.Exists(configPath))
         {
             var cfg = AppConfig.Load(configPath);
-            var env = ExecEnv.Create(cfg.ShellEnvironmentPolicy);
+            var policy = cfg.ShellEnvironmentPolicy;
+            if (inh != null) policy.Inherit = inh.Value;
+            if (ign != null) policy.IgnoreDefaultExcludes = ign.Value;
+            if (exc.Length > 0) policy.Exclude = exc.Select(EnvironmentVariablePattern.CaseInsensitive).ToList();
+            if (set.Length > 0) policy.Set = set.Select(s => s.Split('=',2)).ToDictionary(p=>p[0], p=>p.Length>1?p[1]:string.Empty);
+            if (inc.Length > 0) policy.IncludeOnly = inc.Select(EnvironmentVariablePattern.CaseInsensitive).ToList();
+            var env = ExecEnv.Create(policy);
             foreach (var (k,v) in env)
                 psi.Environment[k] = v;
         }

--- a/codex-dotnet/CodexCli/Commands/ExecBinder.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecBinder.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Binding;
 using System.CommandLine.Parsing;
+using CodexCli.Config;
 
 namespace CodexCli.Commands;
 
@@ -28,6 +29,11 @@ public class ExecBinder : BinderBase<ExecOptions>
     private readonly Option<bool> _noProjectDoc;
     private readonly Option<bool> _json;
     private readonly Option<string?> _eventLog;
+    private readonly Option<ShellEnvironmentPolicyInherit?> _envInherit;
+    private readonly Option<bool?> _envIgnore;
+    private readonly Option<string[]> _envExclude;
+    private readonly Option<string[]> _envSet;
+    private readonly Option<string[]> _envInclude;
 
     public ExecBinder(Argument<string?> prompt, Option<FileInfo[]> images, Option<string?> model,
         Option<string?> profile, Option<string?> provider, Option<bool> fullAuto,
@@ -36,7 +42,9 @@ public class ExecBinder : BinderBase<ExecOptions>
         Option<string[]> notify, Option<string[]> overrides, Option<ReasoningEffort?> effort,
         Option<ReasoningSummary?> summary, Option<string?> instructions,
         Option<bool?> hideReasoning, Option<bool?> disableStorage,
-        Option<bool> noProjectDoc, Option<bool> json, Option<string?> eventLog)
+        Option<bool> noProjectDoc, Option<bool> json, Option<string?> eventLog,
+        Option<ShellEnvironmentPolicyInherit?> envInherit, Option<bool?> envIgnore,
+        Option<string[]> envExclude, Option<string[]> envSet, Option<string[]> envInclude)
     {
         _prompt = prompt;
         _images = images;
@@ -60,6 +68,11 @@ public class ExecBinder : BinderBase<ExecOptions>
         _noProjectDoc = noProjectDoc;
         _json = json;
         _eventLog = eventLog;
+        _envInherit = envInherit;
+        _envIgnore = envIgnore;
+        _envExclude = envExclude;
+        _envSet = envSet;
+        _envInclude = envInclude;
     }
 
     protected override ExecOptions GetBoundValue(BindingContext bindingContext)
@@ -90,7 +103,12 @@ public class ExecBinder : BinderBase<ExecOptions>
             bindingContext.ParseResult.GetValueForOption(_disableStorage),
             bindingContext.ParseResult.GetValueForOption(_noProjectDoc),
             bindingContext.ParseResult.GetValueForOption(_json),
-            bindingContext.ParseResult.GetValueForOption(_eventLog)
+            bindingContext.ParseResult.GetValueForOption(_eventLog),
+            bindingContext.ParseResult.GetValueForOption(_envInherit),
+            bindingContext.ParseResult.GetValueForOption(_envIgnore),
+            bindingContext.ParseResult.GetValueForOption(_envExclude) ?? Array.Empty<string>(),
+            bindingContext.ParseResult.GetValueForOption(_envSet) ?? Array.Empty<string>(),
+            bindingContext.ParseResult.GetValueForOption(_envInclude) ?? Array.Empty<string>()
         );
     }
 }

--- a/codex-dotnet/CodexCli/Commands/ExecBinder.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecBinder.cs
@@ -34,6 +34,8 @@ public class ExecBinder : BinderBase<ExecOptions>
     private readonly Option<string[]> _envExclude;
     private readonly Option<string[]> _envSet;
     private readonly Option<string[]> _envInclude;
+    private readonly Option<int?> _docMaxBytes;
+    private readonly Option<string?> _docPath;
 
     public ExecBinder(Argument<string?> prompt, Option<FileInfo[]> images, Option<string?> model,
         Option<string?> profile, Option<string?> provider, Option<bool> fullAuto,
@@ -44,7 +46,8 @@ public class ExecBinder : BinderBase<ExecOptions>
         Option<bool?> hideReasoning, Option<bool?> disableStorage,
         Option<bool> noProjectDoc, Option<bool> json, Option<string?> eventLog,
         Option<ShellEnvironmentPolicyInherit?> envInherit, Option<bool?> envIgnore,
-        Option<string[]> envExclude, Option<string[]> envSet, Option<string[]> envInclude)
+        Option<string[]> envExclude, Option<string[]> envSet, Option<string[]> envInclude,
+        Option<int?> docMaxBytes, Option<string?> docPath)
     {
         _prompt = prompt;
         _images = images;
@@ -73,6 +76,8 @@ public class ExecBinder : BinderBase<ExecOptions>
         _envExclude = envExclude;
         _envSet = envSet;
         _envInclude = envInclude;
+        _docMaxBytes = docMaxBytes;
+        _docPath = docPath;
     }
 
     protected override ExecOptions GetBoundValue(BindingContext bindingContext)
@@ -108,7 +113,9 @@ public class ExecBinder : BinderBase<ExecOptions>
             bindingContext.ParseResult.GetValueForOption(_envIgnore),
             bindingContext.ParseResult.GetValueForOption(_envExclude) ?? Array.Empty<string>(),
             bindingContext.ParseResult.GetValueForOption(_envSet) ?? Array.Empty<string>(),
-            bindingContext.ParseResult.GetValueForOption(_envInclude) ?? Array.Empty<string>()
+            bindingContext.ParseResult.GetValueForOption(_envInclude) ?? Array.Empty<string>(),
+            bindingContext.ParseResult.GetValueForOption(_docMaxBytes),
+            bindingContext.ParseResult.GetValueForOption(_docPath)
         );
     }
 }

--- a/codex-dotnet/CodexCli/Commands/ExecCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecCommand.cs
@@ -197,6 +197,13 @@ public static class ExecCommand
                 {
                     case AgentMessageEvent am:
                         SessionManager.AddEntry(sessionId, am.Message);
+                        if (cfg != null)
+                            await MessageHistory.AppendEntryAsync(am.Message, sessionId, cfg);
+                        break;
+                    case AddToHistoryEvent ah:
+                        SessionManager.AddEntry(sessionId, ah.Text);
+                        if (cfg != null)
+                            await MessageHistory.AppendEntryAsync(ah.Text, sessionId, cfg);
                         break;
                     case ExecApprovalRequestEvent ar:
                         var prog = ar.Command.First();

--- a/codex-dotnet/CodexCli/Commands/ExecCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecCommand.cs
@@ -1,7 +1,6 @@
 using System.CommandLine;
 using CodexCli.Config;
 using CodexCli.Util;
-using CodexCli.Config;
 using CodexCli.Protocol;
 using CodexCli.ApplyPatch;
 using System.Linq;
@@ -170,7 +169,7 @@ public static class ExecCommand
             var sandboxLabel = opts.FullAuto
                 ? "full-auto"
                 : (sandboxList.Count > 0 ? string.Join(',', sandboxList.Select(s => s.ToString())) : "default");
-            var processor = new CodexCli.Protocol.EventProcessor(withAnsi, !hideReason);
+            var processor = new CodexCli.Protocol.EventProcessor(withAnsi, !hideReason, cfg?.FileOpener ?? UriBasedFileOpener.None, Environment.CurrentDirectory);
             processor.PrintConfigSummary(
                 opts.Model ?? cfg?.Model ?? "default",
                 opts.ModelProvider ?? cfg?.ModelProvider ?? string.Empty,

--- a/codex-dotnet/CodexCli/Commands/ExecCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecCommand.cs
@@ -39,6 +39,8 @@ public static class ExecCommand
         var envExcludeOpt = new Option<string[]>("--env-exclude") { AllowMultipleArgumentsPerToken = true };
         var envSetOpt = new Option<string[]>("--env-set") { AllowMultipleArgumentsPerToken = true };
         var envIncludeOpt = new Option<string[]>("--env-include-only") { AllowMultipleArgumentsPerToken = true };
+        var docMaxOpt = new Option<int?>("--project-doc-max-bytes", "Limit size of AGENTS.md to read");
+        var docPathOpt = new Option<string?>("--project-doc-path", "Explicit project doc path");
 
         var cmd = new Command("exec", "Run Codex non-interactively");
         cmd.AddArgument(promptArg);
@@ -68,11 +70,13 @@ public static class ExecCommand
         cmd.AddOption(envExcludeOpt);
         cmd.AddOption(envSetOpt);
         cmd.AddOption(envIncludeOpt);
+        cmd.AddOption(docMaxOpt);
+        cmd.AddOption(docPathOpt);
 
         var binder = new ExecBinder(promptArg, imagesOpt, modelOpt, profileOpt, providerOpt, fullAutoOpt,
             approvalOpt, sandboxOpt, colorOpt, cwdOpt, lastMsgOpt, skipGitOpt, notifyOpt, overridesOpt,
             effortOpt, summaryOpt, instrOpt, hideReasonOpt, disableStorageOpt, noProjDocOpt, jsonOpt, eventLogOpt,
-            envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt);
+            envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt, docMaxOpt, docPathOpt);
 
         cmd.SetHandler(async (ExecOptions opts, string? cfgPath, string? cd) =>
         {
@@ -116,7 +120,7 @@ public static class ExecCommand
                 {
                     var inst = opts.InstructionsPath != null && File.Exists(opts.InstructionsPath)
                         ? File.ReadAllText(opts.InstructionsPath)
-                        : cfg != null ? ProjectDoc.GetUserInstructions(cfg, Environment.CurrentDirectory, opts.NoProjectDoc) : null;
+                        : cfg != null ? ProjectDoc.GetUserInstructions(cfg, Environment.CurrentDirectory, opts.NoProjectDoc, opts.ProjectDocMaxBytes, opts.ProjectDocPath) : null;
                     if (!string.IsNullOrWhiteSpace(inst))
                     {
                         prompt = inst;

--- a/codex-dotnet/CodexCli/Commands/ExecCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecCommand.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using CodexCli.Config;
 using CodexCli.Util;
+using CodexCli.Config;
 using CodexCli.Protocol;
 using CodexCli.ApplyPatch;
 using System.Linq;
@@ -81,6 +82,7 @@ public static class ExecCommand
             if (!string.IsNullOrEmpty(cfgPath) && File.Exists(cfgPath))
                 cfg = AppConfig.Load(cfgPath, opts.Profile);
 
+            SessionManager.SetPersistence(cfg?.History.Persistence ?? HistoryPersistence.SaveAll);
             var sessionId = SessionManager.CreateSession();
             StreamWriter? logWriter = null;
             if (opts.EventLogFile != null)
@@ -308,8 +310,10 @@ public static class ExecCommand
                                     }
                                     File.WriteAllLines(full, lines);
                                     break;
-                            }
+                                }
                         }
+                        break;
+                    case TaskStartedEvent tsEvent:
                         break;
                     case TaskCompleteEvent tc:
                         if (providerId == "mock")

--- a/codex-dotnet/CodexCli/Commands/ExecOptions.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecOptions.cs
@@ -36,4 +36,6 @@ public record ExecOptions(
     bool? EnvIgnoreDefaultExcludes,
     string[] EnvExclude,
     string[] EnvSet,
-    string[] EnvIncludeOnly);
+    string[] EnvIncludeOnly,
+    int? ProjectDocMaxBytes,
+    string? ProjectDocPath);

--- a/codex-dotnet/CodexCli/Commands/ExecOptions.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecOptions.cs
@@ -1,3 +1,5 @@
+using CodexCli.Config;
+
 namespace CodexCli.Commands;
 
 public enum ColorMode
@@ -29,4 +31,9 @@ public record ExecOptions(
     bool? DisableResponseStorage,
     bool NoProjectDoc,
     bool Json,
-    string? EventLogFile);
+    string? EventLogFile,
+    ShellEnvironmentPolicyInherit? EnvInherit,
+    bool? EnvIgnoreDefaultExcludes,
+    string[] EnvExclude,
+    string[] EnvSet,
+    string[] EnvIncludeOnly);

--- a/codex-dotnet/CodexCli/Commands/HistoryCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/HistoryCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using CodexCli.Util;
+using CodexCli.Config;
 
 namespace CodexCli.Commands;
 
@@ -67,6 +68,25 @@ public static class HistoryCommand
             else Console.WriteLine("not found");
         }, idArg, offsetArg);
 
+        var msgMetaCmd = new Command("messages-meta", "Show message history metadata");
+        msgMetaCmd.SetHandler(async () =>
+        {
+            var cfg = new AppConfig();
+            var meta = await MessageHistory.HistoryMetadataAsync(cfg);
+            Console.WriteLine($"log {meta.LogId} count {meta.Count}");
+        });
+
+        var msgEntryCmd = new Command("messages-entry", "Show message history entry by offset");
+        var msgOffsetArg = new Argument<int>("offset", "Entry offset");
+        msgEntryCmd.AddArgument(msgOffsetArg);
+        msgEntryCmd.SetHandler((int offset) =>
+        {
+            var cfg = new AppConfig();
+            var text = MessageHistory.LookupEntry(0, offset, cfg);
+            if (text != null) Console.WriteLine(text);
+            else Console.WriteLine("not found");
+        }, msgOffsetArg);
+
         var root = new Command("history", "Manage session history");
         root.AddCommand(listCmd);
         root.AddCommand(showCmd);
@@ -75,6 +95,8 @@ public static class HistoryCommand
         root.AddCommand(purgeCmd);
         root.AddCommand(entryCmd);
         root.AddCommand(infoCmd);
+        root.AddCommand(msgMetaCmd);
+        root.AddCommand(msgEntryCmd);
         return root;
     }
 }

--- a/codex-dotnet/CodexCli/Commands/HistoryCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/HistoryCommand.cs
@@ -87,6 +87,48 @@ public static class HistoryCommand
             else Console.WriteLine("not found");
         }, msgOffsetArg);
 
+        var msgPathCmd = new Command("messages-path", "Print message history file path");
+        msgPathCmd.SetHandler(() =>
+        {
+            var cfg = new AppConfig();
+            Console.WriteLine(MessageHistory.GetHistoryFile(cfg));
+        });
+
+        var msgClearCmd = new Command("messages-clear", "Delete message history file");
+        msgClearCmd.SetHandler(() =>
+        {
+            var cfg = new AppConfig();
+            MessageHistory.ClearHistory(cfg);
+        });
+
+        var msgSearchCmd = new Command("messages-search", "Search message history for text");
+        var termArg = new Argument<string>("term", "Search term");
+        msgSearchCmd.AddArgument(termArg);
+        msgSearchCmd.SetHandler(async (string term) =>
+        {
+            var cfg = new AppConfig();
+            var results = await MessageHistory.SearchEntriesAsync(term, cfg);
+            foreach (var r in results) Console.WriteLine(r);
+        }, termArg);
+
+        var msgLastCmd = new Command("messages-last", "Show last N history entries");
+        var lastCountArg = new Argument<int>("n", getDefaultValue: () => 10);
+        msgLastCmd.AddArgument(lastCountArg);
+        msgLastCmd.SetHandler(async (int n) =>
+        {
+            var cfg = new AppConfig();
+            var lines = await MessageHistory.LastEntriesAsync(n, cfg);
+            foreach (var l in lines) Console.WriteLine(l);
+        }, lastCountArg);
+
+        var msgCountCmd = new Command("messages-count", "Print number of history entries");
+        msgCountCmd.SetHandler(async () =>
+        {
+            var cfg = new AppConfig();
+            var count = await MessageHistory.CountEntriesAsync(cfg);
+            Console.WriteLine(count);
+        });
+
         var root = new Command("history", "Manage session history");
         root.AddCommand(listCmd);
         root.AddCommand(showCmd);
@@ -97,6 +139,11 @@ public static class HistoryCommand
         root.AddCommand(infoCmd);
         root.AddCommand(msgMetaCmd);
         root.AddCommand(msgEntryCmd);
+        root.AddCommand(msgPathCmd);
+        root.AddCommand(msgClearCmd);
+        root.AddCommand(msgSearchCmd);
+        root.AddCommand(msgLastCmd);
+        root.AddCommand(msgCountCmd);
         return root;
     }
 }

--- a/codex-dotnet/CodexCli/Commands/HistoryCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/HistoryCommand.cs
@@ -113,13 +113,22 @@ public static class HistoryCommand
 
         var msgLastCmd = new Command("messages-last", "Show last N history entries");
         var lastCountArg = new Argument<int>("n", getDefaultValue: () => 10);
+        var jsonOpt = new Option<bool>("--json", "Output JSON array");
         msgLastCmd.AddArgument(lastCountArg);
-        msgLastCmd.SetHandler(async (int n) =>
+        msgLastCmd.AddOption(jsonOpt);
+        msgLastCmd.SetHandler(async (int n, bool json) =>
         {
             var cfg = new AppConfig();
             var lines = await MessageHistory.LastEntriesAsync(n, cfg);
-            foreach (var l in lines) Console.WriteLine(l);
-        }, lastCountArg);
+            if (json)
+            {
+                Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(lines));
+            }
+            else
+            {
+                foreach (var l in lines) Console.WriteLine(l);
+            }
+        }, lastCountArg, jsonOpt);
 
         var msgCountCmd = new Command("messages-count", "Print number of history entries");
         msgCountCmd.SetHandler(async () =>

--- a/codex-dotnet/CodexCli/Commands/HistoryCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/HistoryCommand.cs
@@ -49,6 +49,13 @@ public static class HistoryCommand
             Console.WriteLine("All sessions deleted");
         });
 
+        var infoCmd = new Command("info", "List sessions with start times");
+        infoCmd.SetHandler(() =>
+        {
+            foreach (var info in SessionManager.ListSessionsWithInfo())
+                Console.WriteLine($"{info.Id} {info.Start:o}");
+        });
+
         var entryCmd = new Command("entry", "Show a single history entry");
         var offsetArg = new Argument<int>("offset", "Entry offset");
         entryCmd.AddArgument(idArg);
@@ -67,6 +74,7 @@ public static class HistoryCommand
         root.AddCommand(pathCmd);
         root.AddCommand(purgeCmd);
         root.AddCommand(entryCmd);
+        root.AddCommand(infoCmd);
         return root;
     }
 }

--- a/codex-dotnet/CodexCli/Commands/HistoryCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/HistoryCommand.cs
@@ -138,6 +138,14 @@ public static class HistoryCommand
             Console.WriteLine(count);
         });
 
+        var msgWatchCmd = new Command("messages-watch", "Watch for new history entries");
+        msgWatchCmd.SetHandler(async () =>
+        {
+            var cfg = new AppConfig();
+            await foreach (var line in MessageHistory.WatchEntriesAsync(cfg, CancellationToken.None))
+                Console.WriteLine(line);
+        });
+
         var root = new Command("history", "Manage session history");
         root.AddCommand(listCmd);
         root.AddCommand(showCmd);
@@ -153,6 +161,7 @@ public static class HistoryCommand
         root.AddCommand(msgSearchCmd);
         root.AddCommand(msgLastCmd);
         root.AddCommand(msgCountCmd);
+        root.AddCommand(msgWatchCmd);
         return root;
     }
 }

--- a/codex-dotnet/CodexCli/Commands/InteractiveBinder.cs
+++ b/codex-dotnet/CodexCli/Commands/InteractiveBinder.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.Binding;
+using CodexCli.Config;
 
 namespace CodexCli.Commands;
 
@@ -26,6 +27,11 @@ public class InteractiveBinder : BinderBase<InteractiveOptions>
     private readonly Option<string?> _lastMessage;
     private readonly Option<bool> _noProjectDoc;
     private readonly Option<string?> _eventLog;
+    private readonly Option<ShellEnvironmentPolicyInherit?> _envInherit;
+    private readonly Option<bool?> _envIgnore;
+    private readonly Option<string[]> _envExclude;
+    private readonly Option<string[]> _envSet;
+    private readonly Option<string[]> _envInclude;
 
     public InteractiveBinder(Argument<string?> prompt, Option<FileInfo[]> images, Option<string?> model,
         Option<string?> profile, Option<string?> provider, Option<bool> fullAuto, Option<ApprovalMode?> approval,
@@ -33,7 +39,9 @@ public class InteractiveBinder : BinderBase<InteractiveOptions>
         Option<string[]> notify, Option<string[]> overrides, Option<ReasoningEffort?> effort,
         Option<ReasoningSummary?> summary, Option<string?> instructions,
         Option<bool?> hideReasoning, Option<bool?> disableStorage,
-        Option<string?> lastMessage, Option<bool> noProjectDoc, Option<string?> eventLog)
+        Option<string?> lastMessage, Option<bool> noProjectDoc, Option<string?> eventLog,
+        Option<ShellEnvironmentPolicyInherit?> envInherit, Option<bool?> envIgnore,
+        Option<string[]> envExclude, Option<string[]> envSet, Option<string[]> envInclude)
     {
         _prompt = prompt;
         _images = images;
@@ -56,6 +64,11 @@ public class InteractiveBinder : BinderBase<InteractiveOptions>
         _lastMessage = lastMessage;
         _noProjectDoc = noProjectDoc;
         _eventLog = eventLog;
+        _envInherit = envInherit;
+        _envIgnore = envIgnore;
+        _envExclude = envExclude;
+        _envSet = envSet;
+        _envInclude = envInclude;
     }
 
     protected override InteractiveOptions GetBoundValue(BindingContext bindingContext)
@@ -82,7 +95,12 @@ public class InteractiveBinder : BinderBase<InteractiveOptions>
             bindingContext.ParseResult.GetValueForOption(_disableStorage),
             bindingContext.ParseResult.GetValueForOption(_lastMessage),
             bindingContext.ParseResult.GetValueForOption(_noProjectDoc),
-            bindingContext.ParseResult.GetValueForOption(_eventLog)
+            bindingContext.ParseResult.GetValueForOption(_eventLog),
+            bindingContext.ParseResult.GetValueForOption(_envInherit),
+            bindingContext.ParseResult.GetValueForOption(_envIgnore),
+            bindingContext.ParseResult.GetValueForOption(_envExclude) ?? Array.Empty<string>(),
+            bindingContext.ParseResult.GetValueForOption(_envSet) ?? Array.Empty<string>(),
+            bindingContext.ParseResult.GetValueForOption(_envInclude) ?? Array.Empty<string>()
         );
     }
 }

--- a/codex-dotnet/CodexCli/Commands/InteractiveBinder.cs
+++ b/codex-dotnet/CodexCli/Commands/InteractiveBinder.cs
@@ -32,6 +32,8 @@ public class InteractiveBinder : BinderBase<InteractiveOptions>
     private readonly Option<string[]> _envExclude;
     private readonly Option<string[]> _envSet;
     private readonly Option<string[]> _envInclude;
+    private readonly Option<int?> _docMaxBytes;
+    private readonly Option<string?> _docPath;
 
     public InteractiveBinder(Argument<string?> prompt, Option<FileInfo[]> images, Option<string?> model,
         Option<string?> profile, Option<string?> provider, Option<bool> fullAuto, Option<ApprovalMode?> approval,
@@ -41,7 +43,8 @@ public class InteractiveBinder : BinderBase<InteractiveOptions>
         Option<bool?> hideReasoning, Option<bool?> disableStorage,
         Option<string?> lastMessage, Option<bool> noProjectDoc, Option<string?> eventLog,
         Option<ShellEnvironmentPolicyInherit?> envInherit, Option<bool?> envIgnore,
-        Option<string[]> envExclude, Option<string[]> envSet, Option<string[]> envInclude)
+        Option<string[]> envExclude, Option<string[]> envSet, Option<string[]> envInclude,
+        Option<int?> docMaxBytes, Option<string?> docPath)
     {
         _prompt = prompt;
         _images = images;
@@ -69,6 +72,8 @@ public class InteractiveBinder : BinderBase<InteractiveOptions>
         _envExclude = envExclude;
         _envSet = envSet;
         _envInclude = envInclude;
+        _docMaxBytes = docMaxBytes;
+        _docPath = docPath;
     }
 
     protected override InteractiveOptions GetBoundValue(BindingContext bindingContext)
@@ -100,7 +105,9 @@ public class InteractiveBinder : BinderBase<InteractiveOptions>
             bindingContext.ParseResult.GetValueForOption(_envIgnore),
             bindingContext.ParseResult.GetValueForOption(_envExclude) ?? Array.Empty<string>(),
             bindingContext.ParseResult.GetValueForOption(_envSet) ?? Array.Empty<string>(),
-            bindingContext.ParseResult.GetValueForOption(_envInclude) ?? Array.Empty<string>()
+            bindingContext.ParseResult.GetValueForOption(_envInclude) ?? Array.Empty<string>(),
+            bindingContext.ParseResult.GetValueForOption(_docMaxBytes),
+            bindingContext.ParseResult.GetValueForOption(_docPath)
         );
     }
 }

--- a/codex-dotnet/CodexCli/Commands/InteractiveCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/InteractiveCommand.cs
@@ -140,6 +140,10 @@ public static class InteractiveCommand
 
     private static void RunInteractive(InteractiveOptions opts, AppConfig? cfg)
     {
+        bool enableMouse = !(cfg?.Tui.DisableMouseCapture ?? false);
+        Console.Write(enableMouse ? "\u001b[?1000h" : "\u001b[?1000l");
+        try
+        {
         SessionManager.SetPersistence(cfg?.History.Persistence ?? HistoryPersistence.SaveAll);
         var sessionId = SessionManager.CreateSession();
         var history = new List<string>();
@@ -274,5 +278,10 @@ public static class InteractiveCommand
             AnsiConsole.MarkupLine($"History saved to [green]{path}[/]");
         if (opts.LastMessageFile != null && lastMessage != null)
             File.WriteAllText(opts.LastMessageFile, lastMessage);
+        }
+        finally
+        {
+            Console.Write("\u001b[?1000l");
+        }
     }
 }

--- a/codex-dotnet/CodexCli/Commands/InteractiveCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/InteractiveCommand.cs
@@ -38,6 +38,8 @@ public static class InteractiveCommand
         var envExcludeOpt = new Option<string[]>("--env-exclude") { AllowMultipleArgumentsPerToken = true };
         var envSetOpt = new Option<string[]>("--env-set") { AllowMultipleArgumentsPerToken = true };
         var envIncludeOpt = new Option<string[]>("--env-include-only") { AllowMultipleArgumentsPerToken = true };
+        var docMaxOpt = new Option<int?>("--project-doc-max-bytes", "Limit size of AGENTS.md to read");
+        var docPathOpt = new Option<string?>("--project-doc-path", "Explicit project doc path");
 
         var cmd = new Command("interactive", "Run interactive TUI session");
         cmd.AddArgument(promptArg);
@@ -66,11 +68,13 @@ public static class InteractiveCommand
         cmd.AddOption(envExcludeOpt);
         cmd.AddOption(envSetOpt);
         cmd.AddOption(envIncludeOpt);
+        cmd.AddOption(docMaxOpt);
+        cmd.AddOption(docPathOpt);
 
         var binder = new InteractiveBinder(promptArg, imagesOpt, modelOpt, profileOpt, providerOpt,
             fullAutoOpt, approvalOpt, sandboxOpt, colorOpt, skipGitOpt, cwdOpt, notifyOpt, overridesOpt,
             effortOpt, summaryOpt, instrOpt, hideReasonOpt, disableStorageOpt, lastMsgOpt, noProjDocOpt, eventLogOpt,
-            envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt);
+            envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt, docMaxOpt, docPathOpt);
 
         cmd.SetHandler(async (InteractiveOptions opts, string? cfgPath, string? cd) =>
         {
@@ -114,7 +118,7 @@ public static class InteractiveCommand
                 {
                     var inst = opts.InstructionsPath != null && File.Exists(opts.InstructionsPath)
                         ? File.ReadAllText(opts.InstructionsPath)
-                        : cfg != null ? ProjectDoc.GetUserInstructions(cfg, Environment.CurrentDirectory, opts.NoProjectDoc) : null;
+                        : cfg != null ? ProjectDoc.GetUserInstructions(cfg, Environment.CurrentDirectory, opts.NoProjectDoc, opts.ProjectDocMaxBytes, opts.ProjectDocPath) : null;
                     if (!string.IsNullOrWhiteSpace(inst))
                         prompt = inst;
                     else

--- a/codex-dotnet/CodexCli/Commands/InteractiveCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/InteractiveCommand.cs
@@ -140,6 +140,7 @@ public static class InteractiveCommand
 
     private static void RunInteractive(InteractiveOptions opts, AppConfig? cfg)
     {
+        SessionManager.SetPersistence(cfg?.History.Persistence ?? HistoryPersistence.SaveAll);
         var sessionId = SessionManager.CreateSession();
         var history = new List<string>();
         string? lastMessage = null;

--- a/codex-dotnet/CodexCli/Commands/InteractiveOptions.cs
+++ b/codex-dotnet/CodexCli/Commands/InteractiveOptions.cs
@@ -28,4 +28,6 @@ public record InteractiveOptions(
     bool? EnvIgnoreDefaultExcludes,
     string[] EnvExclude,
     string[] EnvSet,
-    string[] EnvIncludeOnly);
+    string[] EnvIncludeOnly,
+    int? ProjectDocMaxBytes,
+    string? ProjectDocPath);

--- a/codex-dotnet/CodexCli/Commands/InteractiveOptions.cs
+++ b/codex-dotnet/CodexCli/Commands/InteractiveOptions.cs
@@ -1,3 +1,5 @@
+using CodexCli.Config;
+
 namespace CodexCli.Commands;
 
 public record InteractiveOptions(
@@ -21,4 +23,9 @@ public record InteractiveOptions(
     bool? DisableResponseStorage,
     string? LastMessageFile,
     bool NoProjectDoc,
-    string? EventLogFile);
+    string? EventLogFile,
+    ShellEnvironmentPolicyInherit? EnvInherit,
+    bool? EnvIgnoreDefaultExcludes,
+    string[] EnvExclude,
+    string[] EnvSet,
+    string[] EnvIncludeOnly);

--- a/codex-dotnet/CodexCli/Commands/LoginBinder.cs
+++ b/codex-dotnet/CodexCli/Commands/LoginBinder.cs
@@ -1,0 +1,52 @@
+using System.CommandLine;
+using System.CommandLine.Binding;
+using CodexCli.Config;
+
+namespace CodexCli.Commands;
+
+public class LoginBinder : BinderBase<LoginOptions>
+{
+    private readonly Option<string[]> _overrides;
+    private readonly Option<string?> _token;
+    private readonly Option<string?> _apiKey;
+    private readonly Option<string?> _provider;
+    private readonly Option<bool> _chatgpt;
+    private readonly Option<ShellEnvironmentPolicyInherit?> _envInherit;
+    private readonly Option<bool?> _envIgnore;
+    private readonly Option<string[]> _envExclude;
+    private readonly Option<string[]> _envSet;
+    private readonly Option<string[]> _envInclude;
+
+    public LoginBinder(Option<string[]> overridesOpt, Option<string?> tokenOpt, Option<string?> apiOpt,
+        Option<string?> providerOpt, Option<bool> chatgptOpt,
+        Option<ShellEnvironmentPolicyInherit?> envInheritOpt, Option<bool?> envIgnoreOpt,
+        Option<string[]> envExcludeOpt, Option<string[]> envSetOpt, Option<string[]> envIncludeOpt)
+    {
+        _overrides = overridesOpt;
+        _token = tokenOpt;
+        _apiKey = apiOpt;
+        _provider = providerOpt;
+        _chatgpt = chatgptOpt;
+        _envInherit = envInheritOpt;
+        _envIgnore = envIgnoreOpt;
+        _envExclude = envExcludeOpt;
+        _envSet = envSetOpt;
+        _envInclude = envIncludeOpt;
+    }
+
+    protected override LoginOptions GetBoundValue(BindingContext bindingContext)
+    {
+        return new LoginOptions(
+            bindingContext.ParseResult.GetValueForOption(_overrides) ?? Array.Empty<string>(),
+            bindingContext.ParseResult.GetValueForOption(_token),
+            bindingContext.ParseResult.GetValueForOption(_apiKey),
+            bindingContext.ParseResult.GetValueForOption(_provider),
+            bindingContext.ParseResult.GetValueForOption(_chatgpt),
+            bindingContext.ParseResult.GetValueForOption(_envInherit),
+            bindingContext.ParseResult.GetValueForOption(_envIgnore),
+            bindingContext.ParseResult.GetValueForOption(_envExclude) ?? Array.Empty<string>(),
+            bindingContext.ParseResult.GetValueForOption(_envSet) ?? Array.Empty<string>(),
+            bindingContext.ParseResult.GetValueForOption(_envInclude) ?? Array.Empty<string>()
+        );
+    }
+}

--- a/codex-dotnet/CodexCli/Commands/LoginOptions.cs
+++ b/codex-dotnet/CodexCli/Commands/LoginOptions.cs
@@ -1,0 +1,15 @@
+namespace CodexCli.Commands;
+
+using CodexCli.Config;
+
+public record LoginOptions(
+    string[] Overrides,
+    string? Token,
+    string? ApiKey,
+    string? Provider,
+    bool ChatGpt,
+    ShellEnvironmentPolicyInherit? EnvInherit,
+    bool? EnvIgnoreDefaultExcludes,
+    string[] EnvExclude,
+    string[] EnvSet,
+    string[] EnvIncludeOnly);

--- a/codex-dotnet/CodexCli/Commands/McpClientCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/McpClientCommand.cs
@@ -1,0 +1,41 @@
+using System.CommandLine;
+using CodexCli.Util;
+using System.Text.Json;
+
+namespace CodexCli.Commands;
+
+public static class McpClientCommand
+{
+    public static Command Create()
+    {
+        var cmd = new Command("mcp-client", "Run MCP client to list tools");
+        var timeoutOpt = new Option<int>("--timeout", () => 10, "Initialization timeout in seconds");
+        var jsonOpt = new Option<bool>("--json", description: "Output JSON");
+        cmd.AddOption(timeoutOpt);
+        cmd.AddOption(jsonOpt);
+        var progArg = new Argument<string>("program");
+        var argsArg = new Argument<string[]>("args") { Arity = ArgumentArity.ZeroOrMore };
+        cmd.AddArgument(progArg);
+        cmd.AddArgument(argsArg);
+        cmd.SetHandler(async (string program, string[] args, int timeout, bool json) =>
+        {
+            using var client = await McpClient.StartAsync(program, args);
+            var initParams = new InitializeRequestParams(
+                new ClientCapabilities(null, null, null),
+                new Implementation("codex-mcp-client", "1.0"),
+                "2025-03-26");
+            var resp = await client.SendRequestAsync("initialize", initParams, timeout);
+            Console.Error.WriteLine($"initialize response: {resp.Result}");
+            var toolsResp = await client.SendRequestAsync("tools/list", null, timeout);
+            if (json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(toolsResp.Result, new JsonSerializerOptions { WriteIndented = true }));
+            }
+            else
+            {
+                Console.WriteLine(toolsResp.Result?.ToString());
+            }
+        }, progArg, argsArg, timeoutOpt, jsonOpt);
+        return cmd;
+    }
+}

--- a/codex-dotnet/CodexCli/Commands/McpClientCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/McpClientCommand.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using CodexCli.Util;
 using System.Text.Json;
+using System.Linq;
 
 namespace CodexCli.Commands;
 
@@ -8,34 +9,47 @@ public static class McpClientCommand
 {
     public static Command Create()
     {
-        var cmd = new Command("mcp-client", "Run MCP client to list tools");
-        var timeoutOpt = new Option<int>("--timeout", () => 10, "Initialization timeout in seconds");
+        var cmd = new Command("mcp-client", "Run MCP client to list or call tools");
+        var timeoutOpt = new Option<int>("--timeout", () => 10, "Request timeout in seconds");
         var jsonOpt = new Option<bool>("--json", description: "Output JSON");
+        var callOpt = new Option<string?>("--call", description: "Tool name to call");
+        var argsOpt = new Option<string?>("--args", description: "JSON arguments for tool");
+        var envOpt = new Option<string[]>("--env", description: "Extra VAR=VAL pairs", getDefaultValue: () => Array.Empty<string>());
         cmd.AddOption(timeoutOpt);
         cmd.AddOption(jsonOpt);
+        cmd.AddOption(callOpt);
+        cmd.AddOption(argsOpt);
+        cmd.AddOption(envOpt);
         var progArg = new Argument<string>("program");
         var argsArg = new Argument<string[]>("args") { Arity = ArgumentArity.ZeroOrMore };
         cmd.AddArgument(progArg);
         cmd.AddArgument(argsArg);
-        cmd.SetHandler(async (string program, string[] args, int timeout, bool json) =>
+        cmd.SetHandler(async (string program, string[] args, int timeout, bool json, string? call, string? arguments, string[] env) =>
         {
-            using var client = await McpClient.StartAsync(program, args);
+            var extraEnv = env.Select(e => e.Split('=', 2)).Where(p => p.Length == 2).ToDictionary(p => p[0], p => p[1]);
+            using var client = await McpClient.StartAsync(program, args, extraEnv);
             var initParams = new InitializeRequestParams(
                 new ClientCapabilities(null, null, null),
                 new Implementation("codex-mcp-client", "1.0"),
                 "2025-03-26");
-            var resp = await client.SendRequestAsync("initialize", initParams, timeout);
-            Console.Error.WriteLine($"initialize response: {resp.Result}");
-            var toolsResp = await client.SendRequestAsync("tools/list", null, timeout);
-            if (json)
+            await client.InitializeAsync(initParams, timeout);
+
+            if (call == null)
             {
-                Console.WriteLine(JsonSerializer.Serialize(toolsResp.Result, new JsonSerializerOptions { WriteIndented = true }));
+                var tools = await client.ListToolsAsync(null, timeout);
+                var obj = JsonSerializer.Serialize(tools, new JsonSerializerOptions { WriteIndented = json });
+                Console.WriteLine(obj);
             }
             else
             {
-                Console.WriteLine(toolsResp.Result?.ToString());
+                JsonElement? argsElem = null;
+                if (!string.IsNullOrEmpty(arguments))
+                    argsElem = JsonDocument.Parse(arguments).RootElement;
+                var result = await client.CallToolAsync(call, argsElem, timeout);
+                var obj = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = json });
+                Console.WriteLine(obj);
             }
-        }, progArg, argsArg, timeoutOpt, jsonOpt);
+        }, progArg, argsArg, timeoutOpt, jsonOpt, callOpt, argsOpt, envOpt);
         return cmd;
     }
 }

--- a/codex-dotnet/CodexCli/Commands/ProviderCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/ProviderCommand.cs
@@ -118,6 +118,17 @@ public static class ProviderCommand
             File.WriteAllText(cfgPath, Toml.FromModel(model));
         }, setId, configOption);
 
+        var loginCmd = new Command("login", "Store API key for a provider");
+        var loginId = new Argument<string>("id");
+        var keyOpt = new Option<string>("--api-key") { IsRequired = true };
+        loginCmd.AddArgument(loginId);
+        loginCmd.AddOption(keyOpt);
+        loginCmd.SetHandler((string id, string key) =>
+        {
+            ApiKeyManager.SaveKey(id, key);
+            Console.WriteLine($"Saved API key for {id}");
+        }, loginId, keyOpt);
+
         var cmd = new Command("provider", "Provider utilities");
         cmd.AddCommand(list);
         cmd.AddCommand(infoCmd);
@@ -125,6 +136,7 @@ public static class ProviderCommand
         cmd.AddCommand(addCmd);
         cmd.AddCommand(removeCmd);
         cmd.AddCommand(setCmd);
+        cmd.AddCommand(loginCmd);
         return cmd;
     }
 }

--- a/codex-dotnet/CodexCli/Config/AppConfig.cs
+++ b/codex-dotnet/CodexCli/Config/AppConfig.cs
@@ -19,6 +19,7 @@ public class AppConfig
     public ShellEnvironmentPolicy ShellEnvironmentPolicy { get; set; } = new();
     public History History { get; set; } = new();
     public UriBasedFileOpener FileOpener { get; set; } = UriBasedFileOpener.None;
+    public int ProjectDocMaxBytes { get; set; } = 32 * 1024;
     public Tui Tui { get; set; } = new();
     public Dictionary<string, ModelProviderInfo> ModelProviders { get; set; } = new();
     public Dictionary<string, ConfigProfile> Profiles { get; set; } = new();
@@ -34,6 +35,8 @@ public class AppConfig
         if (model.TryGetValue("model_provider", out var mp)) cfg.ModelProvider = mp?.ToString();
         if (model.TryGetValue("codex_home", out var h)) cfg.CodexHome = h?.ToString();
         if (model.TryGetValue("instructions", out var inst)) cfg.Instructions = inst?.ToString();
+        if (model.TryGetValue("project_doc_max_bytes", out var pdm) && int.TryParse(pdm?.ToString(), out var pdmv))
+            cfg.ProjectDocMaxBytes = pdmv;
         if (model.TryGetValue("hide_agent_reasoning", out var har))
             cfg.HideAgentReasoning = har is bool hb ? hb : bool.TryParse(har?.ToString(), out var b) && b;
         if (model.TryGetValue("disable_response_storage", out var drsVal))
@@ -104,6 +107,8 @@ public class AppConfig
                         cp.ModelReasoningEffort = mrev2;
                     if (pm.TryGetValue("model_reasoning_summary", out var mrs2) && Enum.TryParse<ReasoningSummary>(mrs2?.ToString(), true, out var mrsv2))
                         cp.ModelReasoningSummary = mrsv2;
+                    if (pm.TryGetValue("project_doc_max_bytes", out var pdm2) && int.TryParse(pdm2?.ToString(), out var pdmv2))
+                        cp.ProjectDocMaxBytes = pdmv2;
                     cfg.Profiles[k] = cp;
                 }
             }
@@ -128,6 +133,7 @@ public class AppConfig
             if (p.DisableResponseStorage != null) cfg.DisableResponseStorage = p.DisableResponseStorage.Value;
             if (p.ModelReasoningEffort != null) cfg.ModelReasoningEffort = p.ModelReasoningEffort;
             if (p.ModelReasoningSummary != null) cfg.ModelReasoningSummary = p.ModelReasoningSummary;
+            if (p.ProjectDocMaxBytes != null) cfg.ProjectDocMaxBytes = p.ProjectDocMaxBytes.Value;
         }
         return cfg;
     }

--- a/codex-dotnet/CodexCli/Config/AppConfig.cs
+++ b/codex-dotnet/CodexCli/Config/AppConfig.cs
@@ -17,6 +17,9 @@ public class AppConfig
     public ReasoningEffort? ModelReasoningEffort { get; set; }
     public ReasoningSummary? ModelReasoningSummary { get; set; }
     public ShellEnvironmentPolicy ShellEnvironmentPolicy { get; set; } = new();
+    public History History { get; set; } = new();
+    public UriBasedFileOpener FileOpener { get; set; } = UriBasedFileOpener.None;
+    public Tui Tui { get; set; } = new();
     public Dictionary<string, ModelProviderInfo> ModelProviders { get; set; } = new();
     public Dictionary<string, ConfigProfile> Profiles { get; set; } = new();
 
@@ -53,6 +56,20 @@ public class AppConfig
                 cfg.ShellEnvironmentPolicy.Set = setd.ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? string.Empty);
             if (sepd.TryGetValue("include_only", out var inc) && inc is object[] incArr)
                 cfg.ShellEnvironmentPolicy.IncludeOnly = incArr.Select(o => EnvironmentVariablePattern.CaseInsensitive(o?.ToString() ?? string.Empty)).ToList();
+        }
+        if (model.TryGetValue("history", out var hist) && hist is IDictionary<string, object?> hmap)
+        {
+            if (hmap.TryGetValue("persistence", out var pval) && Enum.TryParse<HistoryPersistence>(pval?.ToString(), true, out var pv))
+                cfg.History.Persistence = pv;
+            if (hmap.TryGetValue("max_bytes", out var mb) && int.TryParse(mb?.ToString(), out var mbv))
+                cfg.History.MaxBytes = mbv;
+        }
+        if (model.TryGetValue("file_opener", out var fo) && Enum.TryParse<UriBasedFileOpener>(fo?.ToString(), true, out var fov))
+            cfg.FileOpener = fov;
+        if (model.TryGetValue("tui", out var tuiVal) && tuiVal is IDictionary<string, object?> tm)
+        {
+            if (tm.TryGetValue("disable_mouse_capture", out var dmc))
+                cfg.Tui.DisableMouseCapture = dmc is bool b3 ? b3 : bool.TryParse(dmc?.ToString(), out var tb) && tb;
         }
         if (model.TryGetValue("model_providers", out var mpMap) && mpMap is IDictionary<string, object?> provMap)
         {

--- a/codex-dotnet/CodexCli/Config/ConfigProfile.cs
+++ b/codex-dotnet/CodexCli/Config/ConfigProfile.cs
@@ -9,4 +9,5 @@ public class ConfigProfile
     public bool? DisableResponseStorage { get; set; }
     public ReasoningEffort? ModelReasoningEffort { get; set; }
     public ReasoningSummary? ModelReasoningSummary { get; set; }
+    public int? ProjectDocMaxBytes { get; set; }
 }

--- a/codex-dotnet/CodexCli/Config/History.cs
+++ b/codex-dotnet/CodexCli/Config/History.cs
@@ -1,0 +1,13 @@
+namespace CodexCli.Config;
+
+public enum HistoryPersistence
+{
+    SaveAll,
+    None,
+}
+
+public class History
+{
+    public HistoryPersistence Persistence { get; set; } = HistoryPersistence.SaveAll;
+    public int? MaxBytes { get; set; }
+}

--- a/codex-dotnet/CodexCli/Config/Tui.cs
+++ b/codex-dotnet/CodexCli/Config/Tui.cs
@@ -1,0 +1,6 @@
+namespace CodexCli.Config;
+
+public class Tui
+{
+    public bool DisableMouseCapture { get; set; }
+}

--- a/codex-dotnet/CodexCli/Config/UriBasedFileOpener.cs
+++ b/codex-dotnet/CodexCli/Config/UriBasedFileOpener.cs
@@ -1,0 +1,22 @@
+namespace CodexCli.Config;
+
+public enum UriBasedFileOpener
+{
+    VsCode,
+    VsCodeInsiders,
+    Windsurf,
+    Cursor,
+    None,
+}
+
+public static class UriBasedFileOpenerExtensions
+{
+    public static string? GetScheme(this UriBasedFileOpener opener) => opener switch
+    {
+        UriBasedFileOpener.VsCode => "vscode",
+        UriBasedFileOpener.VsCodeInsiders => "vscode-insiders",
+        UriBasedFileOpener.Windsurf => "windsurf",
+        UriBasedFileOpener.Cursor => "cursor",
+        _ => null,
+    };
+}

--- a/codex-dotnet/CodexCli/Program.cs
+++ b/codex-dotnet/CodexCli/Program.cs
@@ -26,6 +26,7 @@ class Program
         root.AddCommand(CompletionCommand.Create(root, configOption, cdOption));
         root.AddCommand(HistoryCommand.Create());
         root.AddCommand(ProviderCommand.Create(configOption));
+        root.AddCommand(McpClientCommand.Create());
         root.AddCommand(ApplyPatchCommand.Create());
         var verCmd = new Command("version", "Print version");
         verCmd.SetHandler(() =>

--- a/codex-dotnet/CodexCli/Protocol/Event.cs
+++ b/codex-dotnet/CodexCli/Protocol/Event.cs
@@ -10,6 +10,7 @@ public record ErrorEvent(string Id, string Message) : Event(Id);
 public record BackgroundEvent(string Id, string Message) : Event(Id);
 public record ExecCommandBeginEvent(string Id, IReadOnlyList<string> Command, string Cwd) : Event(Id);
 public record ExecCommandEndEvent(string Id, string Stdout, string Stderr, int ExitCode) : Event(Id);
+public record TaskStartedEvent(string Id) : Event(Id);
 public record TaskCompleteEvent(string Id, string? LastAgentMessage) : Event(Id);
 public record ExecApprovalRequestEvent(string Id, IReadOnlyList<string> Command) : Event(Id);
 public record PatchApplyApprovalRequestEvent(string Id, string PatchSummary) : Event(Id);

--- a/codex-dotnet/CodexCli/Protocol/EventProcessor.cs
+++ b/codex-dotnet/CodexCli/Protocol/EventProcessor.cs
@@ -114,6 +114,9 @@ public class EventProcessor
                 else
                     AnsiConsole.MarkupLine($"{ts} history entry {ge.Offset} not found");
                 break;
+            case TaskStartedEvent tsE:
+                AnsiConsole.MarkupLine($"{ts} task started");
+                break;
             case TaskCompleteEvent tc:
                 AnsiConsole.MarkupLine($"{ts} task complete");
                 if (tc.LastAgentMessage != null)

--- a/codex-dotnet/CodexCli/Protocol/MockCodexAgent.cs
+++ b/codex-dotnet/CodexCli/Protocol/MockCodexAgent.cs
@@ -15,6 +15,7 @@ public static async IAsyncEnumerable<Event> RunAsync(string prompt, IReadOnlyLis
         await Task.Delay(10);
     }
         yield return new SessionConfiguredEvent(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "gpt-4");
+        yield return new TaskStartedEvent(Guid.NewGuid().ToString());
         await Task.Delay(50);
         var msgId = Guid.NewGuid().ToString();
         yield return new AgentMessageEvent(msgId, $"Echoing: {prompt.Trim()}");

--- a/codex-dotnet/CodexCli/Util/ChatGptLogin.cs
+++ b/codex-dotnet/CodexCli/Util/ChatGptLogin.cs
@@ -10,7 +10,7 @@ public static class ChatGptLogin
 
     public static string GetScriptPath() => ScriptPath;
 
-    public static async Task<string> LoginAsync(string codexHome, bool captureOutput)
+    public static async Task<string> LoginAsync(string codexHome, bool captureOutput, IDictionary<string,string>? env = null)
     {
         var psi = new ProcessStartInfo("python3", ScriptPath)
         {
@@ -19,6 +19,11 @@ public static class ChatGptLogin
             UseShellExecute = false,
         };
         psi.Environment["CODEX_HOME"] = codexHome;
+        if (env != null)
+        {
+            foreach (var (k,v) in env)
+                psi.Environment[k] = v;
+        }
         try
         {
             using var proc = Process.Start(psi) ?? throw new InvalidOperationException("python3 not found");

--- a/codex-dotnet/CodexCli/Util/JsonToToml.cs
+++ b/codex-dotnet/CodexCli/Util/JsonToToml.cs
@@ -8,7 +8,19 @@ public static class JsonToToml
 {
     public static string ConvertToToml(JsonElement element)
     {
-        var model = Convert(element);
+        object model;
+        if (element.ValueKind == JsonValueKind.Array)
+        {
+            var tbl = new TomlTable();
+            int i = 0;
+            foreach (var v in element.EnumerateArray())
+                tbl[i++.ToString()] = Convert(v);
+            model = tbl;
+        }
+        else
+        {
+            model = Convert(element);
+        }
         return Toml.FromModel(model);
     }
 

--- a/codex-dotnet/CodexCli/Util/JsonToToml.cs
+++ b/codex-dotnet/CodexCli/Util/JsonToToml.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Tomlyn.Model;
+using Tomlyn;
+
+namespace CodexCli.Util;
+
+public static class JsonToToml
+{
+    public static string ConvertToToml(JsonElement element)
+    {
+        var model = Convert(element);
+        return Toml.FromModel(model);
+    }
+
+    private static object? Convert(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => ToTable(element),
+            JsonValueKind.Array => ToArray(element),
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.TryGetInt64(out var i) ? i : element.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null,
+        };
+    }
+
+    private static TomlTable ToTable(JsonElement obj)
+    {
+        var table = new TomlTable();
+        foreach (var prop in obj.EnumerateObject())
+            table[prop.Name] = Convert(prop.Value);
+        return table;
+    }
+
+    private static TomlArray ToArray(JsonElement arr)
+    {
+        var a = new TomlArray();
+        foreach (var v in arr.EnumerateArray())
+            a.Add(Convert(v));
+        return a;
+    }
+}

--- a/codex-dotnet/CodexCli/Util/MarkdownUtils.cs
+++ b/codex-dotnet/CodexCli/Util/MarkdownUtils.cs
@@ -1,0 +1,23 @@
+using System.Text.RegularExpressions;
+using CodexCli.Config;
+
+namespace CodexCli.Util;
+
+public static class MarkdownUtils
+{
+    private static readonly Regex CitationRegex = new("【F:([^†]+)†L(\\d+)(?:-L(\\d+|\\?))?】", RegexOptions.Compiled);
+
+    public static string RewriteFileCitations(string src, UriBasedFileOpener opener, string cwd)
+    {
+        var scheme = opener.GetScheme();
+        if (scheme == null) return src;
+        return CitationRegex.Replace(src, m =>
+        {
+            var file = m.Groups[1].Value;
+            var line = m.Groups[2].Value;
+            var path = Path.IsPathRooted(file) ? Path.GetFullPath(file) : Path.GetFullPath(Path.Combine(cwd, file));
+            path = path.Replace("\\", "/");
+            return $"[{file}:{line}]({scheme}://file{path}:{line}) ";
+        });
+    }
+}

--- a/codex-dotnet/CodexCli/Util/McpClient.cs
+++ b/codex-dotnet/CodexCli/Util/McpClient.cs
@@ -1,0 +1,107 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Collections.Concurrent;
+using CodexCli.Protocol;
+
+namespace CodexCli.Util;
+
+public class McpClient : IDisposable
+{
+    private readonly Process _process;
+    private readonly StreamWriter _stdin;
+    private readonly StreamReader _stdout;
+    private readonly ConcurrentDictionary<int, TaskCompletionSource<JsonRpcMessage>> _pending = new();
+    private int _nextId = 1;
+    private readonly CancellationTokenSource _cts = new();
+
+    private McpClient(Process process)
+    {
+        _process = process;
+        _stdin = process.StandardInput;
+        _stdout = process.StandardOutput;
+        Task.Run(ReaderLoop);
+    }
+
+    public static async Task<McpClient> StartAsync(string program, IEnumerable<string> args, IDictionary<string, string>? env = null)
+    {
+        var psi = new ProcessStartInfo(program)
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = false,
+            UseShellExecute = false
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        if (env != null)
+        {
+            psi.Environment.Clear();
+            foreach (var kv in env) psi.Environment[kv.Key] = kv.Value;
+        }
+        var p = Process.Start(psi) ?? throw new InvalidOperationException("failed to start process");
+        return new McpClient(p);
+    }
+
+    private async Task ReaderLoop()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            var line = await _stdout.ReadLineAsync();
+            if (line == null) break;
+            try
+            {
+                var msg = JsonSerializer.Deserialize<JsonRpcMessage>(line);
+                if (msg?.Id is JsonElement idElem && idElem.ValueKind == JsonValueKind.Number && idElem.TryGetInt32(out var id))
+                {
+                    if (_pending.TryRemove(id, out var tcs))
+                        tcs.TrySetResult(msg);
+                }
+            }
+            catch
+            {
+                // ignore malformed lines
+            }
+        }
+    }
+
+    public async Task<JsonRpcMessage> SendRequestAsync(string method, object? parameters, int timeoutSeconds = 10)
+    {
+        int id = Interlocked.Increment(ref _nextId);
+        var msg = new JsonRpcMessage
+        {
+            Method = method,
+            Params = parameters != null ? JsonSerializer.SerializeToElement(parameters) : null,
+            Id = JsonSerializer.SerializeToElement(id)
+        };
+        var json = JsonSerializer.Serialize(msg);
+        await _stdin.WriteLineAsync(json);
+        await _stdin.FlushAsync();
+        var tcs = new TaskCompletionSource<JsonRpcMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _pending[id] = tcs;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+        await using var reg = cts.Token.Register(() => tcs.TrySetCanceled());
+        return await tcs.Task;
+    }
+
+    public Task SendNotificationAsync(string method, object? parameters)
+    {
+        var msg = new JsonRpcMessage
+        {
+            Method = method,
+            Params = parameters != null ? JsonSerializer.SerializeToElement(parameters) : null
+        };
+        var json = JsonSerializer.Serialize(msg);
+        return _stdin.WriteLineAsync(json);
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        try { if (!_process.HasExited) _process.Kill(); } catch { }
+        _process.Dispose();
+    }
+}
+
+public record ClientCapabilities(object? Experimental, object? Roots, object? Sampling);
+public record Implementation(string Name, string Version);
+public record InitializeRequestParams(ClientCapabilities Capabilities, Implementation ClientInfo, string ProtocolVersion);
+

--- a/codex-dotnet/CodexCli/Util/MessageHistory.cs
+++ b/codex-dotnet/CodexCli/Util/MessageHistory.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using CodexCli.Config;
+
+namespace CodexCli.Util;
+
+public static class MessageHistory
+{
+    private const string HistoryFile = "history.jsonl";
+
+    private static string GetHistoryPath(AppConfig cfg)
+    {
+        var home = cfg.CodexHome ?? EnvUtils.FindCodexHome();
+        return Path.Combine(home, HistoryFile);
+    }
+
+    public class HistoryEntry
+    {
+        public string SessionId { get; set; } = string.Empty;
+        public ulong Ts { get; set; }
+        public string Text { get; set; } = string.Empty;
+    }
+
+    public static async Task AppendEntryAsync(string text, string sessionId, AppConfig cfg)
+    {
+        if (cfg.History.Persistence == HistoryPersistence.None)
+            return;
+        var path = GetHistoryPath(cfg);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var entry = new HistoryEntry
+        {
+            SessionId = sessionId,
+            Ts = (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Text = text
+        };
+        var line = JsonSerializer.Serialize(entry) + "\n";
+        await File.AppendAllTextAsync(path, line);
+        if (!OperatingSystem.IsWindows())
+        {
+            try { File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite); } catch {}
+        }
+    }
+
+    public static async Task<(ulong LogId, int Count)> HistoryMetadataAsync(AppConfig cfg)
+    {
+        var path = GetHistoryPath(cfg);
+        if (!File.Exists(path)) return (0, 0);
+        int count = 0;
+        await foreach (var _ in File.ReadLinesAsync(path))
+            count++;
+        return (0UL, count);
+    }
+
+    public static string? LookupEntry(ulong logId, int offset, AppConfig cfg)
+    {
+        var path = GetHistoryPath(cfg);
+        if (!File.Exists(path)) return null;
+        using var sr = new StreamReader(path);
+        for (int i = 0; i <= offset; i++)
+        {
+            var line = sr.ReadLine();
+            if (line == null) return null;
+            if (i == offset)
+            {
+                try
+                {
+                    var entry = JsonSerializer.Deserialize<HistoryEntry>(line);
+                    return entry?.Text;
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/codex-dotnet/CodexCli/Util/NotifyUtils.cs
+++ b/codex-dotnet/CodexCli/Util/NotifyUtils.cs
@@ -4,7 +4,7 @@ namespace CodexCli.Util;
 
 public static class NotifyUtils
 {
-    public static void RunNotify(string[] command, string arg)
+    public static void RunNotify(string[] command, string arg, IDictionary<string,string>? env = null)
     {
         if (command.Length == 0) return;
         try
@@ -18,6 +18,11 @@ public static class NotifyUtils
             foreach (var c in command.Skip(1))
                 psi.ArgumentList.Add(c);
             psi.ArgumentList.Add(arg);
+            if (env != null)
+            {
+                foreach (var (k,v) in env)
+                    psi.Environment[k] = v;
+            }
             Process.Start(psi);
         }
         catch

--- a/codex-dotnet/CodexCli/Util/ProjectDoc.cs
+++ b/codex-dotnet/CodexCli/Util/ProjectDoc.cs
@@ -4,33 +4,38 @@ namespace CodexCli.Util;
 
 public static class ProjectDoc
 {
-    private const int MaxBytes = 32 * 1024;
+    private const int DefaultMaxBytes = 32 * 1024;
     private const string Separator = "\n\n--- project-doc ---\n\n";
 
-    private static string? LoadFirstCandidate(string dir)
+    private static string? LoadFile(string path, int maxBytes)
     {
-        var candidate = Path.Combine(dir, "AGENTS.md");
-        if (!File.Exists(candidate)) return null;
-        var bytes = File.ReadAllBytes(candidate);
-        if (bytes.Length > MaxBytes)
-            bytes = bytes.Take(MaxBytes).ToArray();
+        if (!File.Exists(path)) return null;
+        var bytes = File.ReadAllBytes(path);
+        if (bytes.Length > maxBytes)
+            bytes = bytes.Take(maxBytes).ToArray();
         var text = System.Text.Encoding.UTF8.GetString(bytes).Trim();
         return string.IsNullOrWhiteSpace(text) ? null : text;
     }
 
-    private static string? FindProjectDoc(string cwd)
+    private static string? LoadFirstCandidate(string dir, int maxBytes)
+    {
+        var candidate = Path.Combine(dir, "AGENTS.md");
+        return LoadFile(candidate, maxBytes);
+    }
+
+    private static string? FindProjectDoc(string cwd, int maxBytes)
     {
         var global = Path.Combine(EnvUtils.FindCodexHome(), "AGENTS.md");
         if (File.Exists(global))
         {
-            var txt = LoadFirstCandidate(Path.GetDirectoryName(global)!);
+            var txt = LoadFile(global, maxBytes);
             if (!string.IsNullOrEmpty(txt)) return txt;
         }
         var dir = new DirectoryInfo(cwd);
         var repoRoot = GitUtils.GetRepoRoot(cwd);
         while (dir != null)
         {
-            var doc = LoadFirstCandidate(dir.FullName);
+            var doc = LoadFirstCandidate(dir.FullName, maxBytes);
             if (doc != null) return doc;
             if (repoRoot != null && dir.FullName == repoRoot) break;
             dir = dir.Parent;
@@ -38,11 +43,24 @@ public static class ProjectDoc
         return null;
     }
 
-    public static string? GetUserInstructions(AppConfig cfg, string cwd, bool skipProjectDoc = false)
+    public static string? GetUserInstructions(AppConfig cfg, string cwd, bool skipProjectDoc = false, int? maxBytesOverride = null, string? docPath = null)
     {
         var disable = skipProjectDoc || Environment.GetEnvironmentVariable("CODEX_DISABLE_PROJECT_DOC") == "1";
+        int maxBytes = maxBytesOverride ?? cfg.ProjectDocMaxBytes;
         var inst = cfg.Instructions;
-        var doc = disable ? null : FindProjectDoc(cwd);
+        string? doc;
+        if (disable)
+        {
+            doc = null;
+        }
+        else if (docPath != null)
+        {
+            doc = LoadFile(docPath, maxBytes);
+        }
+        else
+        {
+            doc = FindProjectDoc(cwd, maxBytes);
+        }
         if (inst != null && doc != null)
             return inst.Trim() + Separator + doc.Trim();
         return inst ?? doc;


### PR DESCRIPTION
## Summary
- allow overriding shell environment policy via CLI options
- support env policy in exec, interactive, debug, and login commands
- pass environment to notifier and ChatGPT login helper
- add LoginBinder/LoginOptions for cleaner login handling
- extend binder tests for new options
- document new features in AGENTS plan

## Testing
- `dotnet build codex-dotnet/CodexCli/CodexCli.csproj -v minimal`
- `dotnet test codex-dotnet/CodexCli.Tests/CodexCli.Tests.csproj --no-build -v minimal` *(fails: hung)*

------
https://chatgpt.com/codex/tasks/task_e_684da9220624832e8f6a2027d69ce05e