### PR TITLE
Add more MCP and replay features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,7 +382,6 @@
 ## TODO Next Run
 - Continue porting remaining Rust CLI features
 - Investigate hanging tests and fix missing API key issues
-- Flesh out CodexToolRunner with real Codex integration
 - Port remaining core utilities from Rust such as conversation replay
 - Expand unit tests for new utilities
 - Continue integrating new utilities into commands
@@ -415,4 +414,14 @@
 381. Added ApiKeyManagerTests covering env fallback
 382. Extended ResponseItemFactoryTests for new event types
 383. Documented progress and updated TODO list
+384. CodexToolRunner now runs RealCodexAgent using OpenAIClient
+385. CodexToolCallParam gained Provider field
+386. McpClientCommand supports --call-codex, --codex-prompt, --codex-model and --codex-provider
+387. ReplayCommand now supports --json and --messages-only options
+388. Added ReplayCommandTests for basic output and JSON mode
+389. ExecParams extended with output limit fields
+390. ExecRunner respects per-call output limits
+391. Added ExecRunnerOutputLimitTests verifying limits
+392. McpClientCommand uses ApiKeyManager when calling Codex
+393. Documented progress and updated TODO list
 

--- a/codex-dotnet/CodexCli.Tests/ExecRunnerOutputLimitTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ExecRunnerOutputLimitTests.cs
@@ -1,0 +1,17 @@
+using CodexCli.Models;
+using CodexCli.Util;
+using Xunit;
+using System.Collections.Generic;
+using System;
+
+public class ExecRunnerOutputLimitTests
+{
+    [Fact]
+    public async Task LimitsOutput()
+    {
+        var p = new ExecParams(new List<string>{"bash","-c","yes | head -n 1000"}, Directory.GetCurrentDirectory(), 1000, new(), 100, 5);
+        var result = await ExecRunner.RunAsync(p, CancellationToken.None);
+        Assert.True(result.Stdout.Split('\n').Length <= 5);
+        Assert.True(result.Stdout.Length <= 100);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/ReplayCommandTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ReplayCommandTests.cs
@@ -1,0 +1,55 @@
+using CodexCli.Commands;
+using CodexCli.Models;
+using CodexCli.Util;
+using System.Collections.Generic;
+using System.IO;
+using System.CommandLine.Builder;
+using System.CommandLine.IO;
+using Xunit;
+
+public class ReplayCommandTests
+{
+    [Fact]
+    public async Task PrintsMessages()
+    {
+        var items = new ResponseItem[]
+        {
+            new MessageItem("assistant", new List<ContentItem>{ new("output_text","hi") }),
+            new FunctionCallItem("tool","{}","1")
+        };
+        var file = Path.GetTempFileName();
+        await using (var w = new StreamWriter(file))
+        {
+            foreach (var i in items)
+                await w.WriteLineAsync(System.Text.Json.JsonSerializer.Serialize(i, i.GetType()));
+        }
+        var cmd = ReplayCommand.Create();
+        var console = new System.CommandLine.IO.TestConsole();
+        var parser = new System.CommandLine.Builder.CommandLineBuilder(cmd).Build();
+        await parser.InvokeAsync(file, console);
+        Assert.Contains("assistant: hi", console.Out.ToString());
+        File.Delete(file);
+    }
+}
+
+    [Fact]
+    public async Task JsonOutput()
+    {
+        var items = new ResponseItem[]
+        {
+            new MessageItem("assistant", new List<ContentItem>{ new("output_text","hi") })
+        };
+        var file = Path.GetTempFileName();
+        await using (var w = new StreamWriter(file))
+        {
+            foreach (var i in items)
+                await w.WriteLineAsync(System.Text.Json.JsonSerializer.Serialize(i, i.GetType()));
+        }
+        var cmd = ReplayCommand.Create();
+        var console = new TestConsole();
+        var parser = new CommandLineBuilder(cmd).Build();
+        await parser.InvokeAsync($"--json {file}", console);
+        Assert.Contains("\"assistant\"", console.Out.ToString());
+        File.Delete(file);
+    }
+}

--- a/codex-dotnet/CodexCli/Commands/McpClientCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/McpClientCommand.cs
@@ -30,6 +30,10 @@ public static class McpClientCommand
         var addPromptMsgOpt = new Option<string?>("--add-prompt-message", description: "System message for prompt");
         var subscribeOpt = new Option<string?>("--subscribe", description: "Subscribe to resource URI");
         var unsubscribeOpt = new Option<string?>("--unsubscribe", description: "Unsubscribe from resource URI");
+        var codexOpt = new Option<bool>("--call-codex", description: "Call codex tool");
+        var codexPromptOpt = new Option<string?>("--codex-prompt", description: "Prompt for codex tool");
+        var codexModelOpt = new Option<string?>("--codex-model");
+        var codexProviderOpt = new Option<string?>("--codex-provider");
         cmd.AddOption(timeoutOpt);
         cmd.AddOption(jsonOpt);
         cmd.AddOption(callOpt);
@@ -49,6 +53,10 @@ public static class McpClientCommand
         cmd.AddOption(addPromptMsgOpt);
         cmd.AddOption(subscribeOpt);
         cmd.AddOption(unsubscribeOpt);
+        cmd.AddOption(codexOpt);
+        cmd.AddOption(codexPromptOpt);
+        cmd.AddOption(codexModelOpt);
+        cmd.AddOption(codexProviderOpt);
         var progArg = new Argument<string>("program");
         var argsArg = new Argument<string[]>("args") { Arity = ArgumentArity.ZeroOrMore };
         cmd.AddArgument(progArg);
@@ -76,6 +84,10 @@ public static class McpClientCommand
             string? addPromptMsg = ctx.ParseResult.GetValueForOption(addPromptMsgOpt);
             string? subscribeUri = ctx.ParseResult.GetValueForOption(subscribeOpt);
             string? unsubscribeUri = ctx.ParseResult.GetValueForOption(unsubscribeOpt);
+            bool callCodex = ctx.ParseResult.GetValueForOption(codexOpt);
+            string? codexPrompt = ctx.ParseResult.GetValueForOption(codexPromptOpt);
+            string? codexModel = ctx.ParseResult.GetValueForOption(codexModelOpt);
+            string? codexProvider = ctx.ParseResult.GetValueForOption(codexProviderOpt);
 
             var extraEnv = env.Select(e => e.Split('=', 2)).Where(p => p.Length == 2).ToDictionary(p => p[0], p => p[1]);
             using var client = await McpClient.StartAsync(program, args, extraEnv);
@@ -139,6 +151,12 @@ public static class McpClientCommand
             {
                 await client.UnsubscribeAsync(new UnsubscribeRequestParams(unsubscribeUri), timeout);
                 Console.WriteLine("ok");
+            }
+            else if (callCodex)
+            {
+                var param = new CodexToolCallParam(codexPrompt ?? string.Empty, codexModel, null, null, null, null, null, codexProvider);
+                var result = await client.CallCodexAsync(param, timeout);
+                Console.WriteLine(JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = json }));
             }
             else if (completePrefix != null)
             {

--- a/codex-dotnet/CodexCli/Models/ExecModels.cs
+++ b/codex-dotnet/CodexCli/Models/ExecModels.cs
@@ -1,6 +1,12 @@
 namespace CodexCli.Models;
 
-public record ExecParams(List<string> Command, string Cwd, int? TimeoutMs, Dictionary<string,string> Env);
+public record ExecParams(
+    List<string> Command,
+    string Cwd,
+    int? TimeoutMs,
+    Dictionary<string,string> Env,
+    int? MaxOutputBytes = null,
+    int? MaxOutputLines = null);
 
 public record ExecToolCallOutput(int ExitCode, string Stdout, string Stderr, TimeSpan Duration);
 


### PR DESCRIPTION
## Summary
- make CodexToolRunner actually run a session via `RealCodexAgent`
- extend CodexToolCallParam with `Provider`
- expose `--call-codex` options in McpClientCommand
- add `--json` and `--messages-only` flags to replay command
- allow ExecRunner output limits per call
- add unit tests covering replay command and output limits
- document progress in AGENTS.md

## Testing
- `dotnet build CodexCli/CodexCli.csproj`
- `dotnet test` *(failed: The argument CodexCli.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_684e7f40d984832e8158975f126e6671