### PR TITLE
Add MCP server support for Exec command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,4 +530,11 @@
 490. Implemented new command and utilities using connection manager
 491. McpConnectionManager exposes HasServer helper
 492. Documented progress and updated TODO list
-493. TODO next run: integrate connection manager with ExecCommand and extend tests
+493. Added --mcp-server option to ExecCommand and ExecOptions
+494. Updated ExecBinder and tests to bind new option
+495. ExecCommand now uses McpConnectionManager when mcp-server specified
+496. Implemented basic Codex tool call via manager returning agent message
+497. Improved AppConfig parser to handle args arrays generically
+498. Build and tests executed (tests pass with many skipped)
+499. Documented progress and updated TODO list
+500. TODO next run: refine MCP integration and handle SSE events

--- a/codex-dotnet/CodexCli.Tests/ExecBinderTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ExecBinderTests.cs
@@ -40,11 +40,12 @@ public class ExecBinderTests
         var envIncludeOpt = new Option<string[]>("--env-include-only") { AllowMultipleArgumentsPerToken = true };
         var docMaxOpt = new Option<int?>("--project-doc-max-bytes");
         var docPathOpt = new Option<string?>("--project-doc-path");
+        var mcpServerOpt = new Option<string?>("--mcp-server");
 
         var binder = new ExecBinder(promptArg, imagesOpt, modelOpt, profileOpt, providerOpt,
             fullAutoOpt, approvalOpt, sandboxOpt, colorOpt, cwdOpt, lastOpt, sessionOpt, skipGitOpt,
             notifyOpt, overridesOpt, effortOpt, summaryOpt, instrOpt, hideReasonOpt, disableStorageOpt,
-            noProjDocOpt, jsonOpt, logOpt, envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt, docMaxOpt, docPathOpt);
+            noProjDocOpt, jsonOpt, logOpt, envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt, docMaxOpt, docPathOpt, mcpServerOpt);
 
         var cmd = new Command("exec");
         cmd.AddArgument(promptArg);
@@ -61,12 +62,13 @@ public class ExecBinderTests
         cmd.AddOption(envExcludeOpt);
         cmd.AddOption(envSetOpt);
         cmd.AddOption(envIncludeOpt);
+        cmd.AddOption(mcpServerOpt);
         ExecOptions? captured = null;
         cmd.SetHandler((ExecOptions o) => captured = o, binder);
         var root = new RootCommand();
         root.AddCommand(cmd);
 
-        await root.InvokeAsync("exec hello --model gpt-4 --full-auto --session abc --hide-agent-reasoning --disable-response-storage --no-project-doc --json --event-log log.txt --env-inherit all --env-ignore-default-excludes --env-exclude FOO --env-set X=1 --env-include-only PATH");
+        await root.InvokeAsync("exec hello --model gpt-4 --full-auto --session abc --hide-agent-reasoning --disable-response-storage --no-project-doc --json --event-log log.txt --env-inherit all --env-ignore-default-excludes --env-exclude FOO --env-set X=1 --env-include-only PATH --mcp-server demo");
 
         Assert.NotNull(captured);
         Assert.Equal("hello", captured!.Prompt);
@@ -83,5 +85,6 @@ public class ExecBinderTests
         Assert.Contains("X=1", captured.EnvSet);
         Assert.Contains("PATH", captured.EnvIncludeOnly);
         Assert.Equal("abc", captured.SessionId);
+        Assert.Equal("demo", captured.McpServer);
     }
 }

--- a/codex-dotnet/CodexCli.Tests/McpServerMessageTests.cs
+++ b/codex-dotnet/CodexCli.Tests/McpServerMessageTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using System.Text.Json;
 using CodexCli.Util;
+using CodexCli.Protocol;
 using Xunit;
 
 public class McpServerMessageTests

--- a/codex-dotnet/CodexCli/Commands/ExecBinder.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecBinder.cs
@@ -37,6 +37,7 @@ public class ExecBinder : BinderBase<ExecOptions>
     private readonly Option<string[]> _envInclude;
     private readonly Option<int?> _docMaxBytes;
     private readonly Option<string?> _docPath;
+    private readonly Option<string?> _mcpServer;
 
     public ExecBinder(Argument<string?> prompt, Option<FileInfo[]> images, Option<string?> model,
         Option<string?> profile, Option<string?> provider, Option<bool> fullAuto,
@@ -48,7 +49,7 @@ public class ExecBinder : BinderBase<ExecOptions>
         Option<bool> noProjectDoc, Option<bool> json, Option<string?> eventLog,
         Option<ShellEnvironmentPolicyInherit?> envInherit, Option<bool?> envIgnore,
         Option<string[]> envExclude, Option<string[]> envSet, Option<string[]> envInclude,
-        Option<int?> docMaxBytes, Option<string?> docPath)
+        Option<int?> docMaxBytes, Option<string?> docPath, Option<string?> mcpServer)
     {
         _prompt = prompt;
         _images = images;
@@ -80,6 +81,7 @@ public class ExecBinder : BinderBase<ExecOptions>
         _envInclude = envInclude;
         _docMaxBytes = docMaxBytes;
         _docPath = docPath;
+        _mcpServer = mcpServer;
     }
 
     protected override ExecOptions GetBoundValue(BindingContext bindingContext)
@@ -118,7 +120,8 @@ public class ExecBinder : BinderBase<ExecOptions>
             bindingContext.ParseResult.GetValueForOption(_envSet) ?? Array.Empty<string>(),
             bindingContext.ParseResult.GetValueForOption(_envInclude) ?? Array.Empty<string>(),
             bindingContext.ParseResult.GetValueForOption(_docMaxBytes),
-            bindingContext.ParseResult.GetValueForOption(_docPath)
+            bindingContext.ParseResult.GetValueForOption(_docPath),
+            bindingContext.ParseResult.GetValueForOption(_mcpServer)
         );
     }
 }

--- a/codex-dotnet/CodexCli/Commands/ExecCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecCommand.cs
@@ -6,6 +6,7 @@ using CodexCli.ApplyPatch;
 using CodexCli.Models;
 using System.Linq;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace CodexCli.Commands;
 
@@ -43,6 +44,7 @@ public static class ExecCommand
         var envIncludeOpt = new Option<string[]>("--env-include-only") { AllowMultipleArgumentsPerToken = true };
         var docMaxOpt = new Option<int?>("--project-doc-max-bytes", "Limit size of AGENTS.md to read");
         var docPathOpt = new Option<string?>("--project-doc-path", "Explicit project doc path");
+        var mcpServerOpt = new Option<string?>("--mcp-server", "Run via MCP server from config");
 
         var cmd = new Command("exec", "Run Codex non-interactively");
         cmd.AddArgument(promptArg);
@@ -75,11 +77,12 @@ public static class ExecCommand
         cmd.AddOption(envIncludeOpt);
         cmd.AddOption(docMaxOpt);
         cmd.AddOption(docPathOpt);
+        cmd.AddOption(mcpServerOpt);
 
         var binder = new ExecBinder(promptArg, imagesOpt, modelOpt, profileOpt, providerOpt, fullAutoOpt,
             approvalOpt, sandboxOpt, colorOpt, cwdOpt, lastMsgOpt, sessionOpt, skipGitOpt, notifyOpt, overridesOpt,
             effortOpt, summaryOpt, instrOpt, hideReasonOpt, disableStorageOpt, noProjDocOpt, jsonOpt, eventLogOpt,
-            envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt, docMaxOpt, docPathOpt);
+            envInheritOpt, envIgnoreOpt, envExcludeOpt, envSetOpt, envIncludeOpt, docMaxOpt, docPathOpt, mcpServerOpt);
 
         cmd.SetHandler(async (ExecOptions opts, string? cfgPath, string? cd) =>
         {
@@ -194,9 +197,32 @@ public static class ExecCommand
                 EnvUtils.GetLogLevel(null));
 
             var imagePaths = opts.Images.Select(i => i.FullName).ToArray();
-            IAsyncEnumerable<Event> events = providerId == "mock"
-                ? CodexCli.Protocol.MockCodexAgent.RunAsync(prompt, imagePaths)
-                : CodexCli.Protocol.RealCodexAgent.RunAsync(prompt, client, opts.Model ?? cfg?.Model ?? "default");
+            IAsyncEnumerable<Event> events;
+            if (!string.IsNullOrEmpty(opts.McpServer))
+            {
+                var (mgr, _) = await McpConnectionManager.CreateAsync(cfg ?? new AppConfig());
+                if (!mgr.HasServer(opts.McpServer))
+                {
+                    Console.Error.WriteLine($"Unknown MCP server '{opts.McpServer}'");
+                    return;
+                }
+                var param = new CodexToolCallParam(prompt ?? string.Empty, opts.Model ?? cfg?.Model, opts.Profile, Environment.CurrentDirectory, null, sandboxList.Select(s => s.ToString()).ToList(), null, providerId);
+                var paramJson = System.Text.Json.JsonSerializer.SerializeToElement(param);
+                var result = await mgr.CallToolAsync(McpConnectionManager.FullyQualifiedToolName(opts.McpServer, "codex"), paramJson);
+                async IAsyncEnumerable<Event> Enumerate()
+                {
+                    var msg = result.Content.FirstOrDefault().ToString();
+                    yield return new AgentMessageEvent(Guid.NewGuid().ToString(), msg);
+                    yield return new TaskCompleteEvent(Guid.NewGuid().ToString(), msg);
+                }
+                events = Enumerate();
+            }
+            else
+            {
+                events = providerId == "mock"
+                    ? CodexCli.Protocol.MockCodexAgent.RunAsync(prompt, imagePaths)
+                    : CodexCli.Protocol.RealCodexAgent.RunAsync(prompt, client, opts.Model ?? cfg?.Model ?? "default");
+            }
             await foreach (var ev in events)
             {
                 if (opts.Json)

--- a/codex-dotnet/CodexCli/Commands/ExecOptions.cs
+++ b/codex-dotnet/CodexCli/Commands/ExecOptions.cs
@@ -40,4 +40,5 @@ public record ExecOptions(
     string[] EnvSet,
     string[] EnvIncludeOnly,
     int? ProjectDocMaxBytes,
-    string? ProjectDocPath);
+    string? ProjectDocPath,
+    string? McpServer);

--- a/codex-dotnet/CodexCli/Config/AppConfig.cs
+++ b/codex-dotnet/CodexCli/Config/AppConfig.cs
@@ -123,7 +123,7 @@ public class AppConfig
                 {
                     var sc = new McpServerConfig(
                         sd.TryGetValue("command", out var c) ? c?.ToString() ?? string.Empty : string.Empty,
-                        sd.TryGetValue("args", out var a) && a is object[] argArr ? argArr.Select(o => o?.ToString() ?? string.Empty).ToList() : new List<string>(),
+                        sd.TryGetValue("args", out var a) && a is IEnumerable<object> argsArr ? argsArr.Select(o => o?.ToString() ?? string.Empty).ToList() : new List<string>(),
                         sd.TryGetValue("env", out var e) && e is IDictionary<string, object?> envd ? envd.ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? string.Empty) : null);
                     cfg.McpServers[name] = sc;
                 }


### PR DESCRIPTION
## Summary
- integrate `McpConnectionManager` with `exec` command
- support `--mcp-server` option via `ExecOptions` and `ExecBinder`
- update AppConfig parser to handle server args arrays
- extend unit tests for binder
- update documentation

## Testing
- `dotnet build codex-dotnet/CodexCli/CodexCli.csproj`
- `dotnet test codex-dotnet/CodexCli.Tests/CodexCli.Tests.csproj --no-build --blame-hang-timeout 30s` *(tests pass with many skipped)*

------
https://chatgpt.com/codex/tasks/task_b_684ecdb6f36483298006445ccc18fc1e