### PR TITLE
Port exec command utils

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@
 - Updated Rust and C# files with status comments marking migrated components done.
 - Added parity for prompt and resource removal plus logging set-level events with
   matching server and cross-language tests.
+- Ported exec_command helper as ExecCommandUtils with tests and integrated user approval prompt.
+
+## Rust to C# Mapping
+- codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
 
 ## TODO Next Run
 - Continue porting remaining Rust CLI features
@@ -155,3 +159,4 @@
 999. TODO next run: cover remaining MCP notifications and polish SSE handling.
 1002. TODO next run: finalize SSE notifications for prompts and resources.
 1005. TODO next run: stabilize new SSE handlers and extend CLI coverage.
+1008. TODO next run: wire ExecCommandUtils into more commands and extend tests.

--- a/codex-dotnet/CodexCli.Tests/ExecCommandUtilsTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ExecCommandUtilsTests.cs
@@ -1,0 +1,28 @@
+using CodexCli.Util;
+using Xunit;
+
+public class ExecCommandUtilsTests
+{
+    [Fact]
+    public void EscapeCommandQuotesArgs()
+    {
+        var cmd = ExecCommandUtils.EscapeCommand(new[]{"foo","bar baz","weird&stuff"});
+        Assert.Equal("foo 'bar baz' 'weird&stuff'", cmd);
+    }
+
+    [Fact]
+    public void StripBashLcReturnsInner()
+    {
+        var cmd = ExecCommandUtils.StripBashLcAndEscape(new[]{"bash","-lc","echo hello"});
+        Assert.Equal("echo hello", cmd);
+    }
+
+    [Fact]
+    public void RelativizeToHomeReturnsRelative()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var path = Path.Combine(home, "dir", "file.txt");
+        var rel = ExecCommandUtils.RelativizeToHome(path);
+        Assert.Equal($"dir{Path.DirectorySeparatorChar}file.txt", rel);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/UserApprovalWidgetTests.cs
+++ b/codex-dotnet/CodexCli.Tests/UserApprovalWidgetTests.cs
@@ -8,7 +8,7 @@ public class UserApprovalWidgetTests
     public void ApproveExecWhenYes()
     {
         var widget = new UserApprovalWidget(() => "y");
-        var dec = widget.PromptExec(new[]{"ls","-l"}, "/tmp");
+        var dec = widget.PromptExec(new[]{"ls","-l"}, "/tmp", null);
         Assert.Equal(ReviewDecision.Approved, dec);
     }
 

--- a/codex-dotnet/CodexCli/Interactive/Widgets/ApprovalModalView.cs
+++ b/codex-dotnet/CodexCli/Interactive/Widgets/ApprovalModalView.cs
@@ -33,7 +33,7 @@ public class ApprovalModalView : IBottomPaneView
         {
             case ExecApprovalRequestEvent e:
                 _summary = string.Join(' ', e.Command);
-                Decision = _widget.PromptExec(e.Command.ToArray(), Environment.CurrentDirectory);
+                Decision = _widget.PromptExec(e.Command.ToArray(), Environment.CurrentDirectory, null);
                 break;
             case PatchApplyApprovalRequestEvent p:
                 _summary = p.PatchSummary;

--- a/codex-dotnet/CodexCli/Interactive/Widgets/UserApprovalWidget.cs
+++ b/codex-dotnet/CodexCli/Interactive/Widgets/UserApprovalWidget.cs
@@ -1,5 +1,6 @@
 using Spectre.Console;
 using CodexCli.Protocol;
+using CodexCli.Util;
 
 namespace CodexCli.Interactive;
 
@@ -16,10 +17,16 @@ public class UserApprovalWidget
         _readLine = readLine ?? Console.ReadLine;
     }
 
-    public ReviewDecision PromptExec(string[] command, string cwd)
+    public ReviewDecision PromptExec(string[] command, string cwd, string? reason = null)
     {
+        var cmd = ExecCommandUtils.StripBashLcAndEscape(command);
+        var cwdDisp = ExecCommandUtils.RelativizeToHome(cwd);
+        cwdDisp = cwdDisp != null ? $"~/{cwdDisp}" : cwd;
+
         AnsiConsole.MarkupLine("[bold]Shell Command[/]");
-        AnsiConsole.MarkupLine($"[dim]{cwd}$[/] {string.Join(' ', command)}");
+        AnsiConsole.MarkupLine($"[dim]{cwdDisp}$[/] {cmd}");
+        if (!string.IsNullOrEmpty(reason))
+            AnsiConsole.MarkupLine(reason);
         AnsiConsole.Markup(Markup.Escape("Allow command? [y/a/n/q] "));
         var input = _readLine()?.Trim().ToLowerInvariant();
         return input switch

--- a/codex-dotnet/CodexCli/Util/ExecCommandUtils.cs
+++ b/codex-dotnet/CodexCli/Util/ExecCommandUtils.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace CodexCli.Util;
+
+/// <summary>
+/// Helper methods for shell command formatting.
+/// Mirrors codex-rs/tui/src/exec_command.rs (done).
+/// </summary>
+public static class ExecCommandUtils
+{
+    private static string EscapeArg(string arg)
+    {
+        if (Regex.IsMatch(arg, "^[a-zA-Z0-9_./+-]+$") )
+            return arg;
+        return "'" + arg.Replace("'", "'\\''") + "'";
+    }
+
+    public static string EscapeCommand(IEnumerable<string> command)
+    {
+        return string.Join(" ", command.Select(EscapeArg));
+    }
+
+    public static string StripBashLcAndEscape(IEnumerable<string> command)
+    {
+        var list = command.ToList();
+        if (list.Count == 3 && list[0] == "bash" && list[1] == "-lc")
+            return list[2];
+        return EscapeCommand(list);
+    }
+
+    public static string? RelativizeToHome(string path)
+    {
+        var full = Path.GetFullPath(path);
+        if (!Path.IsPathRooted(full))
+            return null;
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home))
+            return null;
+        if (full.StartsWith(home))
+        {
+            var rel = full.Substring(home.Length);
+            rel = rel.TrimStart(Path.DirectorySeparatorChar);
+            return rel.Length == 0 ? string.Empty : rel;
+        }
+        return null;
+    }
+}

--- a/codex-dotnet/CodexTui/Program.cs
+++ b/codex-dotnet/CodexTui/Program.cs
@@ -62,7 +62,7 @@ class Program
         {
             return Task.FromResult(ev switch
             {
-                ExecApprovalRequestEvent e => widget.PromptExec(e.Command.ToArray(), Environment.CurrentDirectory),
+                ExecApprovalRequestEvent e => widget.PromptExec(e.Command.ToArray(), Environment.CurrentDirectory, null),
                 PatchApplyApprovalRequestEvent p => widget.PromptPatch(p.PatchSummary),
                 _ => ReviewDecision.Denied
             });

--- a/codex-rs/tui/src/exec_command.rs
+++ b/codex-rs/tui/src/exec_command.rs
@@ -1,3 +1,4 @@
+// C# port implemented in codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
 use std::path::Path;
 use std::path::PathBuf;
 


### PR DESCRIPTION
## Summary
- add ExecCommandUtils.cs and map from Rust exec_command.rs
- integrate new helper in UserApprovalWidget
- update TUI Program and ApprovalModalView for new signature
- add ExecCommandUtils unit tests and update UserApprovalWidget tests
- mark exec_command.rs with status comment and update AGENTS.md

## Testing
- `dotnet test codex-dotnet/CodexCli.Tests/CodexCli.Tests.csproj -c Release --no-build --filter FullyQualifiedName~ExecCommandUtilsTests`

------
https://chatgpt.com/codex/tasks/task_b_68566380b9188329a17436be9965908e