### PR TITLE
Add chat completions aggregator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 - Ported ChatGptLogin helper and added unit test ensuring script deployment.
 - Ported ExecPolicy loader and added unit tests verifying command filtering.
 - Connected ChatGptLogin into LoginCommand with injectable delegate and added new unit test.
+- Ported debug sandbox and proto commands with a new ProtoCommand unit test.
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
 - codex-rs/core/src/is_safe_command.rs -> codex-dotnet/CodexCli/Util/SafeCommand.cs (done)
@@ -57,6 +58,8 @@
 - codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)
 - codex-rs/login/src/lib.rs -> codex-dotnet/CodexCli/Util/ChatGptLogin.cs (done)
 - codex-rs/cli/src/login.rs -> codex-dotnet/CodexCli/Commands/LoginCommand.cs (done)
+- codex-rs/cli/src/debug_sandbox.rs -> codex-dotnet/CodexCli/Commands/DebugCommand.cs (done)
+- codex-rs/cli/src/proto.rs -> codex-dotnet/CodexCli/Commands/ProtoCommand.cs (done)
 - codex-rs/core/src/safety.rs -> codex-dotnet/CodexCli/Util/Safety.cs (done)
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
@@ -77,3 +80,4 @@
 - Add AppConfig loading parity tests and wire into remaining commands.
 - Port remaining Codex session workflow (submission loop, rollout persistence) to .NET.
 - Expand ResponseItem coverage with integration tests for new event types.
+- Wire DebugCommand and ProtoCommand into parity tests and CLI workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - Implemented CodexWrapper session initialization with unit and CLI parity tests.
 - Ported protocol event types and serialization helpers with parity tests.
 - Ported AppConfig loader and integrated CodexWrapper into CodexToolRunner.
+- Implemented Codex spawn interface and added unit and CLI parity tests.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -40,6 +41,7 @@
 - codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
+- codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 
 ## TODO
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
@@ -48,5 +50,4 @@
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
 - Integrate CodexWrapper into other CLI commands.
-- Port Codex high-level spawn interface from codex.rs and update integration tests.
 - Add AppConfig loading parity tests and wire into remaining commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - Added Ctrl+C signal handling to ExecCommand via SignalUtils and verified cancellation with new tests.
 - Fixed project paths in cross-language tests so MSBuild can locate the .NET projects.
 - Fixed ExecEnv to ignore duplicate environment variables and removed default log level output to match Rust CLI.
+- Added unit test covering duplicate environment variable handling in ExecEnv.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -62,6 +63,7 @@
 ## TODO
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
 - Expand CLI and cross-language parity tests and fix flakes, including chat aggregation.
+- Add CLI parity test for ExecEnv duplicate handling.
 - Resolve exec parity test failures by aligning provider configuration between implementations.
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils (partial: ExecCommand).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 - Integrated safety checks into ExecCommand using sandbox-aware policies and added SequenceEqualityComparer helper.
 - Added Ctrl+C signal handling to ExecCommand via SignalUtils and verified cancellation with new tests.
 - Fixed project paths in cross-language tests so MSBuild can locate the .NET projects.
+- Fixed ExecEnv to ignore duplicate environment variables and removed default log level output to match Rust CLI.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -61,6 +62,7 @@
 ## TODO
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
 - Expand CLI and cross-language parity tests and fix flakes, including chat aggregation.
+- Resolve exec parity test failures by aligning provider configuration between implementations.
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils (partial: ExecCommand).
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - Added unit test covering duplicate environment variable handling in ExecEnv.
 - Ported json_to_toml helper and added unit tests verifying TOML conversion.
 - Ported ChatGptLogin helper and added unit test ensuring script deployment.
+- Ported ExecPolicy loader and added unit tests verifying command filtering.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -51,6 +52,7 @@
 - codex-rs/core/src/mcp_tool_call.rs -> codex-dotnet/CodexCli/Util/McpToolCall.cs (done)
 - codex-rs/core/src/mcp_connection_manager.rs -> codex-dotnet/CodexCli/Util/McpConnectionManager.cs (done)
 - codex-rs/mcp-server/src/json_to_toml.rs -> codex-dotnet/CodexCli/Util/JsonToToml.cs (done)
+- codex-rs/execpolicy/src/lib.rs -> codex-dotnet/CodexCli/Util/ExecPolicy.cs (done)
 - codex-rs/core/src/chat_completions.rs -> codex-dotnet/CodexCli/Util/ChatCompletions.cs (done)
 - codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)
 - codex-rs/login/src/lib.rs -> codex-dotnet/CodexCli/Util/ChatGptLogin.cs (done)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - Integrated CodexWrapper into InteractiveApp for session startup parity.
 - Integrated safety checks into ExecCommand using sandbox-aware policies and added SequenceEqualityComparer helper.
 - Added Ctrl+C signal handling to ExecCommand via SignalUtils and verified cancellation with new tests.
+- Fixed project paths in cross-language tests so MSBuild can locate the .NET projects.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Ported project documentation, user notifications, environment flags, model provider registry, config profile helpers, configuration types, conversation and message history, approval mode parsing, config overrides, elapsed time helpers and MCP tool call.
 - Updated Rust and C# sources with status comments and added parity tests for each port.
 - Implemented ChatCompletions aggregator and hooked it into ModelClient with new unit and integration tests.
+- Fixed recursion bug in ResponseStream.Aggregate and verified aggregation tests pass.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -37,3 +38,4 @@
 - Expand CLI and cross-language parity tests and fix flakes, including chat aggregation.
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
+- Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
 - Integrated CodexWrapper into ExecCommand for session startup parity.
 - Ported safety check helpers and updated cross-CLI tests for interactive save.
 - Integrated CodexWrapper into InteractiveApp for session startup parity.
+- Integrated safety checks into ExecCommand using sandbox-aware policies and added SequenceEqualityComparer helper.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -49,7 +50,7 @@
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
-- codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial)
+ - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
 - codex-rs/core/src/models.rs -> codex-dotnet/CodexCli/Models/ResponseItem.cs (done)
 - codex-rs/core/src/rollout.rs -> codex-dotnet/CodexCli/Util/RolloutRecorder.cs and Commands/ReplayCommand.cs (done)
@@ -59,7 +60,6 @@
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
 - Expand CLI and cross-language parity tests and fix flakes, including chat aggregation.
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
-- Integrate Safety checks into ExecCommand for patch and command approval.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
 - Add AppConfig loading parity tests and wire into remaining commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - Fixed recursion bug in ResponseStream.Aggregate and verified aggregation tests pass.
 - Ported Codex error enums and EnvVarError helper with new unit tests.
 - Implemented CodexWrapper session initialization with unit and CLI parity tests.
+- Ported protocol event types and serialization helpers with parity tests.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -36,6 +37,7 @@
 - codex-rs/core/src/chat_completions.rs -> codex-dotnet/CodexCli/Util/ChatCompletions.cs (done)
 - codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
+- codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
 
 ## TODO
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
@@ -44,3 +46,4 @@
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
 - Integrate CodexWrapper into CodexToolRunner and other CLI commands.
+- Port Codex high-level spawn interface from codex.rs and update integration tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - Ported Codex error enums and EnvVarError helper with new unit tests.
 - Implemented CodexWrapper session initialization with unit and CLI parity tests.
 - Ported protocol event types and serialization helpers with parity tests.
+- Ported AppConfig loader and integrated CodexWrapper into CodexToolRunner.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -27,6 +28,7 @@
 - codex-rs/core/src/model_provider_info.rs -> codex-dotnet/CodexCli/Config/ModelProviderInfo.cs (done)
 - codex-rs/core/src/config_profile.rs -> codex-dotnet/CodexCli/Config/ConfigProfile.cs (done)
 - codex-rs/core/src/config_types.rs -> codex-dotnet/CodexCli/Config/{History.cs,ShellEnvironmentPolicy.cs,Tui.cs,UriBasedFileOpener.cs,ReasoningModels.cs} (done)
+- codex-rs/core/src/config.rs -> codex-dotnet/CodexCli/Config/AppConfig.cs (done)
 - codex-rs/core/src/client_common.rs -> codex-dotnet/CodexCli/{Models/{Prompt.cs,ResponseEvent.cs,ReasoningModels.cs},Util/{ReasoningUtils.cs,ModelClient.cs}} (done)
 - codex-rs/core/src/conversation_history.rs -> codex-dotnet/CodexCli/Util/ConversationHistory.cs (done)
 - codex-rs/core/src/message_history.rs -> codex-dotnet/CodexCli/Util/MessageHistory.cs (done)
@@ -45,5 +47,6 @@
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
-- Integrate CodexWrapper into CodexToolRunner and other CLI commands.
+- Integrate CodexWrapper into other CLI commands.
 - Port Codex high-level spawn interface from codex.rs and update integration tests.
+- Add AppConfig loading parity tests and wire into remaining commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - Fixed ExecEnv to ignore duplicate environment variables and removed default log level output to match Rust CLI.
 - Added unit test covering duplicate environment variable handling in ExecEnv.
 - Ported json_to_toml helper and added unit tests verifying TOML conversion.
+- Ported ChatGptLogin helper and added unit test ensuring script deployment.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -52,6 +53,7 @@
 - codex-rs/mcp-server/src/json_to_toml.rs -> codex-dotnet/CodexCli/Util/JsonToToml.cs (done)
 - codex-rs/core/src/chat_completions.rs -> codex-dotnet/CodexCli/Util/ChatCompletions.cs (done)
 - codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)
+- codex-rs/login/src/lib.rs -> codex-dotnet/CodexCli/Util/ChatGptLogin.cs (done)
 - codex-rs/core/src/safety.rs -> codex-dotnet/CodexCli/Util/Safety.cs (done)
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
@@ -72,3 +74,4 @@
 - Add AppConfig loading parity tests and wire into remaining commands.
 - Port remaining Codex session workflow (submission loop, rollout persistence) to .NET.
 - Expand ResponseItem coverage with integration tests for new event types.
+- Hook ChatGptLogin into LoginCommand and validate login flow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Ported model client agent (RealCodexAgent) with streaming tests.
 - Ported response and rollout models with RolloutRecorder and replay parity tests.
 - Integrated CodexWrapper into ExecCommand for session startup parity.
+- Ported safety check helpers and updated cross-CLI tests for interactive save.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -40,8 +41,10 @@
 - codex-rs/common/src/config_override.rs -> codex-dotnet/CodexCli/Config/ConfigOverrides.cs (done)
 - codex-rs/common/src/elapsed.rs -> codex-dotnet/CodexCli/Util/Elapsed.cs (done)
 - codex-rs/core/src/mcp_tool_call.rs -> codex-dotnet/CodexCli/Util/McpToolCall.cs (done)
+- codex-rs/core/src/mcp_connection_manager.rs -> codex-dotnet/CodexCli/Util/McpConnectionManager.cs (done)
 - codex-rs/core/src/chat_completions.rs -> codex-dotnet/CodexCli/Util/ChatCompletions.cs (done)
 - codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)
+- codex-rs/core/src/safety.rs -> codex-dotnet/CodexCli/Util/Safety.cs (done)
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
@@ -54,6 +57,7 @@
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
 - Expand CLI and cross-language parity tests and fix flakes, including chat aggregation.
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
+- Integrate Safety checks into ExecCommand for patch and command approval.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
 - Integrate CodexWrapper into remaining CLI commands like interactive mode.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Migrated utilities such as ExecCommandUtils, SafeCommand, ExecRunner/ExecEnv, OpenAiApiKey, OpenAiTools, Backoff, GitUtils and SignalUtils.
 - Ported project documentation, user notifications, environment flags, model provider registry, config profile helpers, configuration types, conversation and message history, approval mode parsing, config overrides, elapsed time helpers and MCP tool call.
 - Updated Rust and C# sources with status comments and added parity tests for each port.
+- Implemented ChatCompletions aggregator and hooked it into ModelClient with new unit and integration tests.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -29,10 +30,10 @@
 - codex-rs/common/src/config_override.rs -> codex-dotnet/CodexCli/Config/ConfigOverrides.cs (done)
 - codex-rs/common/src/elapsed.rs -> codex-dotnet/CodexCli/Util/Elapsed.cs (done)
 - codex-rs/core/src/mcp_tool_call.rs -> codex-dotnet/CodexCli/Util/McpToolCall.cs (done)
+- codex-rs/core/src/chat_completions.rs -> codex-dotnet/CodexCli/Util/ChatCompletions.cs (done)
 
 ## TODO
-- Integrate newly ported utilities throughout CLI commands.
-- Port remaining MCP features such as chat_completions.rs to ChatClient.cs and finalize SSE handling.
-- Expand CLI and cross-language parity tests and fix flakes.
+- Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
+- Expand CLI and cross-language parity tests and fix flakes, including chat aggregation.
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 - Ported json_to_toml helper and added unit tests verifying TOML conversion.
 - Ported ChatGptLogin helper and added unit test ensuring script deployment.
 - Ported ExecPolicy loader and added unit tests verifying command filtering.
-
+- Connected ChatGptLogin into LoginCommand with injectable delegate and added new unit test.
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
 - codex-rs/core/src/is_safe_command.rs -> codex-dotnet/CodexCli/Util/SafeCommand.cs (done)
@@ -56,6 +56,7 @@
 - codex-rs/core/src/chat_completions.rs -> codex-dotnet/CodexCli/Util/ChatCompletions.cs (done)
 - codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)
 - codex-rs/login/src/lib.rs -> codex-dotnet/CodexCli/Util/ChatGptLogin.cs (done)
+- codex-rs/cli/src/login.rs -> codex-dotnet/CodexCli/Commands/LoginCommand.cs (done)
 - codex-rs/core/src/safety.rs -> codex-dotnet/CodexCli/Util/Safety.cs (done)
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
@@ -76,4 +77,3 @@
 - Add AppConfig loading parity tests and wire into remaining commands.
 - Port remaining Codex session workflow (submission loop, rollout persistence) to .NET.
 - Expand ResponseItem coverage with integration tests for new event types.
-- Hook ChatGptLogin into LoginCommand and validate login flow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 - Fixed project paths in cross-language tests so MSBuild can locate the .NET projects.
 - Fixed ExecEnv to ignore duplicate environment variables and removed default log level output to match Rust CLI.
 - Added unit test covering duplicate environment variable handling in ExecEnv.
+- Ported json_to_toml helper and added unit tests verifying TOML conversion.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -48,6 +49,7 @@
 - codex-rs/common/src/elapsed.rs -> codex-dotnet/CodexCli/Util/Elapsed.cs (done)
 - codex-rs/core/src/mcp_tool_call.rs -> codex-dotnet/CodexCli/Util/McpToolCall.cs (done)
 - codex-rs/core/src/mcp_connection_manager.rs -> codex-dotnet/CodexCli/Util/McpConnectionManager.cs (done)
+- codex-rs/mcp-server/src/json_to_toml.rs -> codex-dotnet/CodexCli/Util/JsonToToml.cs (done)
 - codex-rs/core/src/chat_completions.rs -> codex-dotnet/CodexCli/Util/ChatCompletions.cs (done)
 - codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)
 - codex-rs/core/src/safety.rs -> codex-dotnet/CodexCli/Util/Safety.cs (done)
@@ -63,7 +65,6 @@
 ## TODO
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
 - Expand CLI and cross-language parity tests and fix flakes, including chat aggregation.
-- Add CLI parity test for ExecEnv duplicate handling.
 - Resolve exec parity test failures by aligning provider configuration between implementations.
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils (partial: ExecCommand).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
 - Ported ExecPolicy loader and added unit tests verifying command filtering.
 - Connected ChatGptLogin into LoginCommand with injectable delegate and added new unit test.
 - Ported debug sandbox and proto commands with a new ProtoCommand unit test.
+- Implemented MCP event streaming helpers (McpEventStream) and added watch-events tests.
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
 - codex-rs/core/src/is_safe_command.rs -> codex-dotnet/CodexCli/Util/SafeCommand.cs (done)
@@ -53,6 +54,7 @@
 - codex-rs/core/src/mcp_tool_call.rs -> codex-dotnet/CodexCli/Util/McpToolCall.cs (done)
 - codex-rs/core/src/mcp_connection_manager.rs -> codex-dotnet/CodexCli/Util/McpConnectionManager.cs (done)
 - codex-rs/mcp-server/src/json_to_toml.rs -> codex-dotnet/CodexCli/Util/JsonToToml.cs (done)
+- codex-rs/mcp-server/src/message_processor.rs -> codex-dotnet/CodexCli/Util/McpEventStream.cs (done)
 - codex-rs/execpolicy/src/lib.rs -> codex-dotnet/CodexCli/Util/ExecPolicy.cs (done)
 - codex-rs/core/src/chat_completions.rs -> codex-dotnet/CodexCli/Util/ChatCompletions.cs (done)
 - codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Ported safety check helpers and updated cross-CLI tests for interactive save.
 - Integrated CodexWrapper into InteractiveApp for session startup parity.
 - Integrated safety checks into ExecCommand using sandbox-aware policies and added SequenceEqualityComparer helper.
+- Added Ctrl+C signal handling to ExecCommand via SignalUtils and verified cancellation with new tests.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -50,7 +51,7 @@
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
- - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety integrated)
+ - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
 - codex-rs/core/src/models.rs -> codex-dotnet/CodexCli/Models/ResponseItem.cs (done)
 - codex-rs/core/src/rollout.rs -> codex-dotnet/CodexCli/Util/RolloutRecorder.cs and Commands/ReplayCommand.cs (done)
@@ -60,7 +61,7 @@
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
 - Expand CLI and cross-language parity tests and fix flakes, including chat aggregation.
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
-- Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
+- Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils (partial: ExecCommand).
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
 - Add AppConfig loading parity tests and wire into remaining commands.
 - Port remaining Codex session workflow (submission loop, rollout persistence) to .NET.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Updated Rust and C# sources with status comments and added parity tests for each port.
 - Implemented ChatCompletions aggregator and hooked it into ModelClient with new unit and integration tests.
 - Fixed recursion bug in ResponseStream.Aggregate and verified aggregation tests pass.
+- Ported Codex error enums and EnvVarError helper with new unit tests.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -32,6 +33,7 @@
 - codex-rs/common/src/elapsed.rs -> codex-dotnet/CodexCli/Util/Elapsed.cs (done)
 - codex-rs/core/src/mcp_tool_call.rs -> codex-dotnet/CodexCli/Util/McpToolCall.cs (done)
 - codex-rs/core/src/chat_completions.rs -> codex-dotnet/CodexCli/Util/ChatCompletions.cs (done)
+- codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)
 
 ## TODO
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
@@ -39,3 +41,4 @@
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
+- Finish port of session initialization via CodexWrapper.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - Implemented Codex spawn interface and added unit and CLI parity tests.
 - Ported model client agent (RealCodexAgent) with streaming tests.
 - Ported response and rollout models with RolloutRecorder and replay parity tests.
+- Integrated CodexWrapper into ExecCommand for session startup parity.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -44,6 +45,7 @@
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
+- codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
 - codex-rs/core/src/models.rs -> codex-dotnet/CodexCli/Models/ResponseItem.cs (done)
 - codex-rs/core/src/rollout.rs -> codex-dotnet/CodexCli/Util/RolloutRecorder.cs and Commands/ReplayCommand.cs (done)
@@ -54,7 +56,7 @@
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
-- Integrate CodexWrapper into other CLI commands.
+- Integrate CodexWrapper into remaining CLI commands like interactive mode.
 - Add AppConfig loading parity tests and wire into remaining commands.
 - Port remaining Codex session workflow (submission loop, rollout persistence) to .NET.
 - Expand ResponseItem coverage with integration tests for new event types.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - Ported response and rollout models with RolloutRecorder and replay parity tests.
 - Integrated CodexWrapper into ExecCommand for session startup parity.
 - Ported safety check helpers and updated cross-CLI tests for interactive save.
+- Integrated CodexWrapper into InteractiveApp for session startup parity.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -52,6 +53,7 @@
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
 - codex-rs/core/src/models.rs -> codex-dotnet/CodexCli/Models/ResponseItem.cs (done)
 - codex-rs/core/src/rollout.rs -> codex-dotnet/CodexCli/Util/RolloutRecorder.cs and Commands/ReplayCommand.cs (done)
+- codex-rs/tui/src/lib.rs -> codex-dotnet/CodexCli/Interactive/InteractiveApp.cs (done)
 
 ## TODO
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
@@ -60,7 +62,6 @@
 - Integrate Safety checks into ExecCommand for patch and command approval.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
-- Integrate CodexWrapper into remaining CLI commands like interactive mode.
 - Add AppConfig loading parity tests and wire into remaining commands.
 - Port remaining Codex session workflow (submission loop, rollout persistence) to .NET.
 - Expand ResponseItem coverage with integration tests for new event types.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@
 - Ported protocol event types and serialization helpers with parity tests.
 - Ported AppConfig loader and integrated CodexWrapper into CodexToolRunner.
 - Implemented Codex spawn interface and added unit and CLI parity tests.
+- Ported model client agent (RealCodexAgent) with streaming tests.
+- Ported response and rollout models with RolloutRecorder and replay parity tests.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -42,6 +44,9 @@
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
+- codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
+- codex-rs/core/src/models.rs -> codex-dotnet/CodexCli/Models/ResponseItem.cs (done)
+- codex-rs/core/src/rollout.rs -> codex-dotnet/CodexCli/Util/RolloutRecorder.cs and Commands/ReplayCommand.cs (done)
 
 ## TODO
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
@@ -51,3 +56,5 @@
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
 - Integrate CodexWrapper into other CLI commands.
 - Add AppConfig loading parity tests and wire into remaining commands.
+- Port remaining Codex session workflow (submission loop, rollout persistence) to .NET.
+- Expand ResponseItem coverage with integration tests for new event types.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Implemented ChatCompletions aggregator and hooked it into ModelClient with new unit and integration tests.
 - Fixed recursion bug in ResponseStream.Aggregate and verified aggregation tests pass.
 - Ported Codex error enums and EnvVarError helper with new unit tests.
+- Implemented CodexWrapper session initialization with unit and CLI parity tests.
 
 ## Rust to C# Mapping
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
@@ -34,6 +35,7 @@
 - codex-rs/core/src/mcp_tool_call.rs -> codex-dotnet/CodexCli/Util/McpToolCall.cs (done)
 - codex-rs/core/src/chat_completions.rs -> codex-dotnet/CodexCli/Util/ChatCompletions.cs (done)
 - codex-rs/core/src/error.rs -> codex-dotnet/CodexCli/Util/CodexErr.cs (done)
+- codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 
 ## TODO
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
@@ -41,4 +43,4 @@
 - Add sandbox enforcement logic and wire ApprovalModeCliArg and ExecEnv into command execution.
 - Improve API key login flow using OpenAiApiKey helper and implement Ctrl+C handling via SignalUtils.
 - Implement CLI comparitive tests ensuring .NET and Rust outputs match for chat aggregation.
-- Finish port of session initialization via CodexWrapper.
+- Integrate CodexWrapper into CodexToolRunner and other CLI commands.

--- a/codex-dotnet/CodexCli.Tests/ChatCompletionsAggregationTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ChatCompletionsAggregationTests.cs
@@ -1,0 +1,27 @@
+using CodexCli.Models;
+using CodexCli.Util;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+public class ChatCompletionsAggregationTests
+{
+    private async IAsyncEnumerable<ResponseEvent> SampleEvents()
+    {
+        yield return new OutputItemDone(new MessageItem("assistant", new List<ContentItem>{ new("output_text", "he") }));
+        yield return new OutputItemDone(new MessageItem("assistant", new List<ContentItem>{ new("output_text", "llo") }));
+        yield return new Completed("1");
+    }
+
+    [Fact]
+    public async Task AggregatesAssistantChunks()
+    {
+        List<ResponseEvent> list = new();
+        await foreach (var ev in SampleEvents().Aggregate())
+            list.Add(ev);
+        Assert.Equal(2, list.Count);
+        var msg = Assert.IsType<OutputItemDone>(list[0]);
+        Assert.Equal("hello", ((MessageItem)msg.Item).Content[0].Text);
+        Assert.IsType<Completed>(list[1]);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexErrTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexErrTests.cs
@@ -1,0 +1,22 @@
+using CodexCli.Util;
+using System.Net;
+using Xunit;
+
+public class CodexErrTests
+{
+    [Fact]
+    public void EnvVarErrorFormatsMessage()
+    {
+        var err = new EnvVarError("API_KEY", "set it");
+        Assert.Contains("API_KEY", err.Message);
+        Assert.Contains("set it", err.Message);
+    }
+
+    [Fact]
+    public void UnexpectedStatusFormatsMessage()
+    {
+        var ex = CodexException.UnexpectedStatus(HttpStatusCode.BadRequest, "oops");
+        Assert.Contains("BadRequest", ex.Message);
+        Assert.Contains("oops", ex.Message);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexSpawnTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexSpawnTests.cs
@@ -1,0 +1,25 @@
+using CodexCli.Protocol;
+using CodexCli.Util;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+public class CodexSpawnTests
+{
+    [Fact]
+    public async Task SpawnReturnsEvents()
+    {
+        var (codex, initId) = await Codex.SpawnAsync(
+            "hi",
+            new OpenAIClient(null, "http://localhost"),
+            "gpt-4",
+            (p,c,m,t) => MockCodexAgent.RunAsync(p, new string[0], null, t));
+
+        Assert.False(string.IsNullOrEmpty(initId));
+        var list = new List<Event>();
+        Event? ev;
+        while ((ev = await codex.NextEventAsync()) != null)
+            list.Add(ev);
+        Assert.Contains(list, e => e is TaskCompleteEvent);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexToolRunnerTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexToolRunnerTests.cs
@@ -1,0 +1,21 @@
+using CodexCli.Protocol;
+using CodexCli.Util;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+public class CodexToolRunnerTests
+{
+    [Fact]
+    public async Task EmitsSessionConfigured()
+    {
+        List<Event> events = new();
+        var param = new CodexToolCallParam("hi", Provider: "mock");
+        var result = await CodexToolRunner.RunCodexToolSessionAsync(param, e => events.Add(e));
+        Assert.NotEmpty(events);
+        Assert.IsType<SessionConfiguredEvent>(events[0]);
+        Assert.Equal("codex done", result.Content[0].GetString());
+    }
+}
+

--- a/codex-dotnet/CodexCli.Tests/CodexWrapperTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexWrapperTests.cs
@@ -1,0 +1,23 @@
+using CodexCli.Protocol;
+using CodexCli.Util;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+public class CodexWrapperTests
+{
+    [Fact]
+    public async Task ExtractsSessionConfigured()
+    {
+        var (stream, first, _cts) = await CodexWrapper.InitCodexAsync(
+            "hi",
+            new OpenAIClient(null, "http://localhost"),
+            "gpt-4",
+            (p, c, m, t) => MockCodexAgent.RunAsync(p, new string[0], null, t));
+        Assert.IsType<SessionConfiguredEvent>(first);
+        List<Event> list = new();
+        await foreach (var ev in stream)
+            list.Add(ev);
+        Assert.Contains(list, e => e is TaskCompleteEvent);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexWrapperTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexWrapperTests.cs
@@ -20,4 +20,21 @@ public class CodexWrapperTests
             list.Add(ev);
         Assert.Contains(list, e => e is TaskCompleteEvent);
     }
+
+    [Fact]
+    public async Task CancelsStream()
+    {
+        var (stream, first, cts) = await CodexWrapper.InitCodexAsync(
+            "hi",
+            new OpenAIClient(null, "http://localhost"),
+            "gpt-4",
+            (p, c, m, t) => MockCodexAgent.RunAsync(p, new string[0], null, t));
+        Assert.IsType<SessionConfiguredEvent>(first);
+        cts.Cancel();
+        List<Event> list = new();
+        await foreach (var ev in stream)
+            list.Add(ev);
+        Assert.Contains(list, e => e is ErrorEvent);
+        Assert.DoesNotContain(list, e => e is TaskCompleteEvent);
+    }
 }

--- a/codex-dotnet/CodexCli.Tests/CrossCliCompatTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CrossCliCompatTests.cs
@@ -712,6 +712,14 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- exec hi -c model_provider=Mock");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
+    [CrossCliFact]
+    public void ExecAggregatedMatches()
+    {
+        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli exec hi --model-provider Mock");
+        var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- exec hi -c model_provider=Mock");
+        Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
+    }
+
 
     [CrossCliFact]
     public void ExecImageUploadMatches()

--- a/codex-dotnet/CodexCli.Tests/CrossCliCompatTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CrossCliCompatTests.cs
@@ -12,7 +12,7 @@ public class CrossCliCompatTests
     [CrossCliFact]
     public void VersionMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli --version");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli --version");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --version");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -20,14 +20,14 @@ public class CrossCliCompatTests
     [CrossCliFact]
     public void HelpMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli --help");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli --help");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --help");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
     [CrossCliFact]
     public void TuiHelpMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexTui --help");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexTui --help");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- --help");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -35,7 +35,7 @@ public class CrossCliCompatTests
     [CrossCliFact]
     public void TuiVersionMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexTui --version");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexTui --version");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- --version");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -43,7 +43,7 @@ public class CrossCliCompatTests
     [CrossCliFact]
     public void TuiLoginScreenMatches()
     {
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check", "q\n");
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check", "q\n");
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- --skip-git-repo-check", "q\n");
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -54,7 +54,7 @@ public class CrossCliCompatTests
     public void TuiChatMatches()
     {
         var input = "hi\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- -c model_provider=Mock --skip-git-repo-check", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -65,7 +65,7 @@ public class CrossCliCompatTests
     public void TuiCtrlDMatches()
     {
         var input = "\u0004";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- -c model_provider=Mock --skip-git-repo-check", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -76,7 +76,7 @@ public class CrossCliCompatTests
     public void TuiCtrlCMatches()
     {
         var input = "hi\n\u0003/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- -c model_provider=Mock --skip-git-repo-check", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -87,7 +87,7 @@ public class CrossCliCompatTests
     public void TuiConfigMatches()
     {
         var input = "/config\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- -c model_provider=Mock --skip-git-repo-check", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -98,7 +98,7 @@ public class CrossCliCompatTests
     public void TuiSessionsMatches()
     {
         var input = "/sessions\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- -c model_provider=Mock --skip-git-repo-check", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -109,7 +109,7 @@ public class CrossCliCompatTests
     public void TuiToggleMouseModeMatches()
     {
         var input = "/toggle-mouse-mode\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- -c model_provider=Mock --skip-git-repo-check", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -119,7 +119,7 @@ public class CrossCliCompatTests
     [CrossCliFact]
     public void InteractiveQuitMatches()
     {
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", "/quit\n");
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", "/quit\n");
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", "/quit\n");
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -130,7 +130,7 @@ public class CrossCliCompatTests
     public void InteractiveCtrlDMatches()
     {
         var seq = "\u0004";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -141,7 +141,7 @@ public class CrossCliCompatTests
     public void InteractiveCtrlCMatches()
     {
         var seq = "hi\n\u0003/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -152,7 +152,7 @@ public class CrossCliCompatTests
     public void InteractiveHistoryMatches()
     {
         var input = "/history\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -163,7 +163,7 @@ public class CrossCliCompatTests
     public void InteractiveConfigMatches()
     {
         var input = "/config\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -174,7 +174,7 @@ public class CrossCliCompatTests
     public void InteractiveScrollMatches()
     {
         var input = "/scroll-up 1\n/scroll-down 1\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -185,7 +185,7 @@ public class CrossCliCompatTests
     public void InteractiveSessionsMatches()
     {
         var input = "/sessions\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -196,7 +196,7 @@ public class CrossCliCompatTests
     public void InteractiveNewMatches()
     {
         var input = "hi\n/new\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -207,7 +207,7 @@ public class CrossCliCompatTests
     public void InteractiveLogMatches()
     {
         var input = "/log\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -218,7 +218,7 @@ public class CrossCliCompatTests
     public void InteractiveVersionMatches()
     {
         var input = "/version\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -230,7 +230,9 @@ public class CrossCliCompatTests
     {
         var tmp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         Directory.CreateDirectory(tmp);
-        var dotnet = RunProcess("bash", $"-c 'cd {tmp} && printf n | dotnet run --project ../../codex-dotnet/CodexTui'");
+        var repoRoot = GitUtils.GetRepoRoot(Directory.GetCurrentDirectory())!;
+        var dotnetProj = Path.Combine(repoRoot, "codex-dotnet", "CodexTui");
+        var dotnet = RunProcess("bash", $"-c 'cd {tmp} && printf n | dotnet run --project {dotnetProj}'");
         var rust = RunProcess("bash", $"-c 'cd {tmp} && printf n | cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml'");
         Directory.Delete(tmp, true);
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
@@ -239,7 +241,7 @@ public class CrossCliCompatTests
     [CrossCliFact]
     public void InteractiveHelpMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli interactive --help");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli interactive --help");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- --help");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -248,7 +250,7 @@ public class CrossCliCompatTests
     [CrossCliFact]
     public void ProviderListMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli provider list --names-only");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli provider list --names-only");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- provider list --names-only");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -256,7 +258,7 @@ public class CrossCliCompatTests
     [CrossCliFact]
     public void HistoryCountMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli history messages-count");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli history messages-count");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- history messages-count");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -265,7 +267,7 @@ public class CrossCliCompatTests
     public void ServersListMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager servers");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager servers");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager servers");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -274,7 +276,7 @@ public class CrossCliCompatTests
     public void RootsListMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager roots list --server test");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager roots list --server test");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager roots list --server test");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -283,7 +285,7 @@ public class CrossCliCompatTests
     public void MessagesCountMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager messages count --server test");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager messages count --server test");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager messages count --server test");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -292,7 +294,7 @@ public class CrossCliCompatTests
     public void MessagesListMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager messages list --server test");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager messages list --server test");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager messages list --server test");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -301,7 +303,7 @@ public class CrossCliCompatTests
     public void PromptsListMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager prompts list --server test");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager prompts list --server test");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager prompts list --server test");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -310,7 +312,7 @@ public class CrossCliCompatTests
     public void PromptGetMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager prompts get --server test demo");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager prompts get --server test demo");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager prompts get --server test demo");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -319,7 +321,7 @@ public class CrossCliCompatTests
     public void ResourcesListMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager resources list --server test");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager resources list --server test");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager resources list --server test");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -328,7 +330,7 @@ public class CrossCliCompatTests
     public void TemplatesListMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager templates --server test");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager templates --server test");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager templates --server test");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -337,7 +339,7 @@ public class CrossCliCompatTests
     public void LoggingSetLevelMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager set-level --server test debug");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager set-level --server test debug");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager set-level --server test debug");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -346,18 +348,20 @@ public class CrossCliCompatTests
     public void AddAndGetMessageMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager messages add --server test hi && dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager messages get --server test 0");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager messages add --server test hi && dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager messages get --server test 0");
         var rust = RunProcess("bash", $"-c 'cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager messages add --server test hi && cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager messages get --server test 0'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
 
     private (string stdout, string stderr) RunProcess(string file, string args, Dictionary<string,string>? env = null)
     {
+        var repoRoot = GitUtils.GetRepoRoot(Directory.GetCurrentDirectory())!;
         var psi = new ProcessStartInfo(file, args)
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            UseShellExecute = false
+            UseShellExecute = false,
+            WorkingDirectory = repoRoot
         };
         if (env != null)
             foreach (var kv in env)
@@ -402,7 +406,7 @@ public class CrossCliCompatTests
         File.WriteAllText(path, """
 [mcp_servers.test]
 command = "dotnet"
-args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
+args = ["run", "--project", "codex-dotnet/CodexCli", "mcp"]
 """);
         return path;
     }
@@ -411,7 +415,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void ServersListJsonMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager servers --json");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager servers --json");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager servers --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -420,7 +424,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void RootsAddJsonMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c 'dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager roots add --server test x && dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager roots list --server test --json'");
+        var dotnet = RunProcess("bash", $"-c 'dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager roots add --server test x && dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager roots list --server test --json'");
         var rust = RunProcess("bash", $"-c 'cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager roots add --server test x && cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager roots list --server test --json'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -429,7 +433,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void PromptsAddJsonMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c 'dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager prompts add --server test demo \"hello\" && dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager prompts get --server test demo --json'");
+        var dotnet = RunProcess("bash", $"-c 'dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager prompts add --server test demo \"hello\" && dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager prompts get --server test demo --json'");
         var rust = RunProcess("bash", $"-c 'cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager prompts add --server test demo \"hello\" && cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager prompts get --server test demo --json'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -438,7 +442,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void MessagesAddJsonMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c 'dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager messages add --server test hi --json && dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager messages get --server test 0 --json'");
+        var dotnet = RunProcess("bash", $"-c 'dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager messages add --server test hi --json && dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager messages get --server test 0 --json'");
         var rust = RunProcess("bash", $"-c 'cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager messages add --server test hi --json && cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager messages get --server test 0 --json'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -447,7 +451,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void ResourcesWriteJsonMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c 'dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager resources write --server test r1 hi --json && dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager resources list --server test --json'");
+        var dotnet = RunProcess("bash", $"-c 'dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager resources write --server test r1 hi --json && dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager resources list --server test --json'");
         var rust = RunProcess("bash", $"-c 'cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager resources write --server test r1 hi --json && cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager resources list --server test --json'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -456,7 +460,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void LoggingSetLevelJsonMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager set-level --server test debug --json");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager set-level --server test debug --json");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager set-level --server test debug --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -466,7 +470,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     {
         var cfg = CreateTempConfig();
         var fq = "test__OAI_CODEX_MCP__codex";
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager call {fq} --json");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli --config {cfg} mcp-manager call {fq} --json");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager call {fq} --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -474,7 +478,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void McpClientPingMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli mcp-client dotnet --project ../codex-dotnet/CodexCli mcp --ping");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli mcp-client dotnet --project codex-dotnet/CodexCli mcp --ping");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/mcp-client/Cargo.toml -- cargo run --quiet --manifest-path ../../codex-rs/mcp-server/Cargo.toml");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -482,7 +486,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void McpClientListToolsMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli mcp-client dotnet --project ../codex-dotnet/CodexCli mcp");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli mcp-client dotnet --project codex-dotnet/CodexCli mcp");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/mcp-client/Cargo.toml -- cargo run --quiet --manifest-path ../../codex-rs/mcp-server/Cargo.toml");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -490,7 +494,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void McpClientListRootsMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli mcp-client dotnet --project ../codex-dotnet/CodexCli mcp --list-roots --json");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli mcp-client dotnet --project codex-dotnet/CodexCli mcp --list-roots --json");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/mcp-client/Cargo.toml -- cargo run --quiet --manifest-path ../../codex-rs/mcp-server/Cargo.toml --list-roots --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -499,7 +503,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager prompts add --server test w hi) & dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager prompts list --server test --events-url http://localhost:8080 --watch-events --json | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager prompts add --server test w hi) & dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager prompts list --server test --events-url http://localhost:8080 --watch-events --json | head -n 2'");
         var rust = RunProcess("bash", $"-c '(sleep 0.2; cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager prompts add --server test w hi) & cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager prompts list --server test --events-url http://localhost:8080 --watch-events --json | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -508,7 +512,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void HistoryWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager prompts add --server test w hi) & dotnet run --project ../codex-dotnet/CodexCli --config {cfg} history messages-meta --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager prompts add --server test w hi) & dotnet run --project codex-dotnet/CodexCli --config {cfg} history messages-meta --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c '(sleep 0.2; cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager prompts add --server test w hi) & cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} history messages-meta --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -517,7 +521,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerClearWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager messages add --server test hi) & dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager messages clear --server test --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager messages add --server test hi) & dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager messages clear --server test --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c '(sleep 0.2; cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager messages add --server test hi) & cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager messages clear --server test --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -526,7 +530,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerAddMessageWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c 'dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager messages add --server test hi --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c 'dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager messages add --server test hi --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c 'cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager messages add --server test hi --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -535,7 +539,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerAddPromptWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c 'dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager prompts add --server test p1 hi --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c 'dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager prompts add --server test p1 hi --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c 'cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager prompts add --server test p1 hi --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -544,7 +548,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerAddRootWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c 'dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager roots add --server test r3 --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c 'dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager roots add --server test r3 --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c 'cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager roots add --server test r3 --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -553,7 +557,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerRemoveRootWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager roots add --server test r4) & dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager roots remove --server test r4 --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager roots add --server test r4) & dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager roots remove --server test r4 --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c '(sleep 0.2; cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager roots add --server test r4) & cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager roots remove --server test r4 --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -562,7 +566,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerWriteResourceWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c 'dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager resources write --server test r2 hi --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c 'dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager resources write --server test r2 hi --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c 'cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager resources write --server test r2 hi --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -571,7 +575,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerSubscribeResourceWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager resources subscribe mem:/s.txt --server test) & dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager resources write --server test mem:/s.txt hi --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager resources subscribe mem:/s.txt --server test) & dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager resources write --server test mem:/s.txt hi --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c '(sleep 0.2; cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager resources subscribe mem:/s.txt --server test) & cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager resources write --server test mem:/s.txt hi --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -580,7 +584,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerRemoveResourceWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager resources write --server test mem:/t.txt hi) & dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager resources remove --server test mem:/t.txt --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager resources write --server test mem:/t.txt hi) & dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager resources remove --server test mem:/t.txt --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c '(sleep 0.2; cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager resources write --server test mem:/t.txt hi) & cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager resources remove --server test mem:/t.txt --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -589,7 +593,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerRemovePromptWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager prompts add --server test p2 hi) & dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager prompts remove --server test p2 --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c '(sleep 0.2; dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager prompts add --server test p2 hi) & dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager prompts remove --server test p2 --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c '(sleep 0.2; cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager prompts add --server test p2 hi) & cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager prompts remove --server test p2 --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -598,7 +602,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void McpManagerSetLevelWatchEventsMatches()
     {
         var cfg = CreateTempConfig();
-        var dotnet = RunProcess("bash", $"-c 'dotnet run --project ../codex-dotnet/CodexCli --config {cfg} mcp-manager set-level --server test debug --events-url http://localhost:8080 --watch-events | head -n 2'");
+        var dotnet = RunProcess("bash", $"-c 'dotnet run --project codex-dotnet/CodexCli --config {cfg} mcp-manager set-level --server test debug --events-url http://localhost:8080 --watch-events | head -n 2'");
         var rust = RunProcess("bash", $"-c 'cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- --config {cfg} mcp-manager set-level --server test debug --events-url http://localhost:8080 --watch-events | head -n 2'");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -606,7 +610,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void HistoryMessagesCountJsonMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli history messages-count --json");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli history messages-count --json");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- history messages-count --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -614,7 +618,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void HistoryMessagesSearchJsonMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli history messages-search hi --json");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli history messages-search hi --json");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- history messages-search hi --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -622,7 +626,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void HistoryMessagesLastJsonMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli history messages-last 1 --json");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli history messages-last 1 --json");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- history messages-last 1 --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -630,7 +634,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void HistoryStatsJsonMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli history stats --json");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli history stats --json");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- history stats --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -641,7 +645,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
         string path = Path.GetTempFileName();
         var item = new MessageItem("assistant", new List<ContentItem>{ new("output_text","hi") });
         File.WriteAllText(path, JsonSerializer.Serialize(item, item.GetType()) + "\n");
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli replay {path} --json");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli replay {path} --json");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- replay {path} --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
         File.Delete(path);
@@ -657,7 +661,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
             new FunctionCallItem("tool","{}","1")
         };
         File.WriteAllLines(path, items.Select(i => JsonSerializer.Serialize(i, i.GetType())));
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli replay {path} --messages-only");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli replay {path} --messages-only");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- replay {path} --messages-only");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
         File.Delete(path);
@@ -672,7 +676,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
         var second = JsonSerializer.Serialize(new MessageItem("assistant", new List<ContentItem>{ new("output_text","a2") }));
         File.WriteAllText(dotPath, first + "\n");
         File.WriteAllText(rustPath, first + "\n");
-        var dotnet = RunProcess("bash", $"-c \"(sleep 0.2; echo '{second}' >> {dotPath}) & dotnet run --project ../codex-dotnet/CodexCli replay {dotPath} --json --follow --max-items 2\"");
+        var dotnet = RunProcess("bash", $"-c \"(sleep 0.2; echo '{second}' >> {dotPath}) & dotnet run --project codex-dotnet/CodexCli replay {dotPath} --json --follow --max-items 2\"");
         var rust = RunProcess("bash", $"-c \"(sleep 0.2; echo '{second}' >> {rustPath}) & cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- replay {rustPath} --json --follow --max-items 2\"");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
         File.Delete(dotPath);
@@ -682,9 +686,9 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void HistoryCountAfterSessionMatches()
     {
-        RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", "/quit\n");
+        RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", "/quit\n");
         RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", "/quit\n");
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli history messages-count");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli history messages-count");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- history messages-count");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -692,7 +696,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void ProviderInfoJsonMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli provider info openai --json");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli provider info openai --json");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- provider info openai --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -700,7 +704,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void ProviderCurrentJsonMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli provider current --json");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli provider current --json");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- provider current --json");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -708,14 +712,14 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     [CrossCliFact]
     public void ExecBasicMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli exec hi --model-provider Mock");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli exec hi --model-provider Mock");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- exec hi -c model_provider=Mock");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
     [CrossCliFact]
     public void ExecAggregatedMatches()
     {
-        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli exec hi --model-provider Mock");
+        var dotnet = RunProcess("dotnet", "run --project codex-dotnet/CodexCli exec hi --model-provider Mock");
         var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- exec hi -c model_provider=Mock");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -725,7 +729,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void ExecImageUploadMatches()
     {
         string path = CreateTempImage();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli exec hi --model-provider Mock --image {path}");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli exec hi --model-provider Mock --image {path}");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- exec hi -c model_provider=Mock --image {path}");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -734,7 +738,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void ExecImageUploadJpegMatches()
     {
         string path = CreateTempJpeg();
-        var dotnet = RunProcess("dotnet", $"run --project ../codex-dotnet/CodexCli exec hi --model-provider Mock --image {path}");
+        var dotnet = RunProcess("dotnet", $"run --project codex-dotnet/CodexCli exec hi --model-provider Mock --image {path}");
         var rust = RunProcess("cargo", $"run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- exec hi -c model_provider=Mock --image {path}");
         Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
     }
@@ -743,7 +747,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void TuiImageUploadMatches()
     {
         string path = CreateTempImage();
-        var dotnet = RunProcessWithPty($"dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock --image {path}", "/quit\n");
+        var dotnet = RunProcessWithPty($"dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock --image {path}", "/quit\n");
         var rust = RunProcessWithPty($"cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- --skip-git-repo-check -c model_provider=Mock --image {path}", "/quit\n");
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -754,7 +758,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void TuiImageUploadJpegMatches()
     {
         string path = CreateTempJpeg();
-        var dotnet = RunProcessWithPty($"dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock --image {path}", "/quit\n");
+        var dotnet = RunProcessWithPty($"dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock --image {path}", "/quit\n");
         var rust = RunProcessWithPty($"cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- --skip-git-repo-check -c model_provider=Mock --image {path}", "/quit\n");
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -766,7 +770,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     {
         string path = CreateTempImage();
         var input = $"/image {path}\n/quit\n";
-        var dotnet = RunProcessWithPty($"dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
+        var dotnet = RunProcessWithPty($"dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
         var rust = RunProcessWithPty($"cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- --skip-git-repo-check -c model_provider=Mock", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -778,7 +782,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     {
         string path = CreateTempJpeg();
         var input = $"/image {path}\n/quit\n";
-        var dotnet = RunProcessWithPty($"dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
+        var dotnet = RunProcessWithPty($"dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
         var rust = RunProcessWithPty($"cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- --skip-git-repo-check -c model_provider=Mock", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -789,7 +793,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void TuiMouseWheelMatches()
     {
         var seq = "\u001b[<64;0;0M\u001b[<65;0;0M/quit\n";
-        var dotnet = RunProcessWithPty($"dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", seq);
+        var dotnet = RunProcessWithPty($"dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", seq);
         var rust = RunProcessWithPty($"cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- --skip-git-repo-check -c model_provider=Mock", seq);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -800,7 +804,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void TuiNonBlockingInputMatches()
     {
         var input = "hello\n/quit\n";
-        var dotnet = RunProcessWithPty($"dotnet run --project ../codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
+        var dotnet = RunProcessWithPty($"dotnet run --project codex-dotnet/CodexTui --skip-git-repo-check --model-provider Mock", input);
         var rust = RunProcessWithPty($"cargo run --quiet --manifest-path ../../codex-rs/tui/Cargo.toml -- --skip-git-repo-check -c model_provider=Mock", input);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -811,7 +815,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void InteractiveArrowEditMatches()
     {
         var seq = "hi\u001b[Da\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -822,7 +826,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void InteractiveHomeEndMatches()
     {
         var seq = "hi\u001b[Ha\u001b[Fb\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -833,7 +837,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void InteractivePasteMatches()
     {
         var seq = "\u001b[200~hi\nthere\u001b[201~\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -844,7 +848,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     public void InteractiveInvalidPasteMatches()
     {
         var seq = "\u001b[200Xab\n/quit\n";
-        var dotnet = RunProcessWithPty("dotnet run --project ../codex-dotnet/CodexCli interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
+        var dotnet = RunProcessWithPty("dotnet run --project codex-dotnet/CodexCli interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var rust = RunProcessWithPty("cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
         var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
@@ -857,7 +861,7 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
         var tmp = Path.GetTempFileName();
         File.Delete(tmp);
         var seq = $"/save {tmp}\n/quit\n";
-        var dotnet = RunProcessWithPty($"dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
+        var dotnet = RunProcessWithPty($"dotnet run --project codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         var rust = RunProcessWithPty($"cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
         File.Delete(tmp);
         var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();

--- a/codex-dotnet/CodexCli.Tests/CrossCliCompatTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CrossCliCompatTests.cs
@@ -851,6 +851,20 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
         Assert.Equal(rOut, dOut);
     }
 
+    [CrossCliFact]
+    public void InteractiveSaveMatches()
+    {
+        var tmp = Path.GetTempFileName();
+        File.Delete(tmp);
+        var seq = $"/save {tmp}\n/quit\n";
+        var dotnet = RunProcessWithPty($"dotnet run --project ../codex-dotnet/CodexCli interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
+        var rust = RunProcessWithPty($"cargo run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- interactive hi --model-provider Mock --hide-agent-reasoning --disable-response-storage --no-project-doc", seq);
+        File.Delete(tmp);
+        var dOut = AnsiEscape.StripAnsi(dotnet.stdout).Trim();
+        var rOut = AnsiEscape.StripAnsi(rust.stdout).Trim();
+        Assert.Equal(rOut, dOut);
+    }
+
     private string CreateTempImage()
     {
         var tmp = Path.GetTempFileName() + ".png";

--- a/codex-dotnet/CodexCli.Tests/CrossCliCompatTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CrossCliCompatTests.cs
@@ -706,6 +706,14 @@ args = ["run", "--project", "../codex-dotnet/CodexCli", "mcp"]
     }
 
     [CrossCliFact]
+    public void ExecBasicMatches()
+    {
+        var dotnet = RunProcess("dotnet", "run --project ../codex-dotnet/CodexCli exec hi --model-provider Mock");
+        var rust = RunProcess("cargo", "run --quiet --manifest-path ../../codex-rs/cli/Cargo.toml -- exec hi -c model_provider=Mock");
+        Assert.Equal(rust.stdout.Trim(), dotnet.stdout.Trim());
+    }
+
+    [CrossCliFact]
     public void ExecImageUploadMatches()
     {
         string path = CreateTempImage();

--- a/codex-dotnet/CodexCli.Tests/EventSerializationTests.cs
+++ b/codex-dotnet/CodexCli.Tests/EventSerializationTests.cs
@@ -1,0 +1,14 @@
+using CodexCli.Protocol;
+using System.Text.Json;
+using Xunit;
+
+public class EventSerializationTests
+{
+    [Fact]
+    public void SessionConfiguredSerializes()
+    {
+        Event ev = new SessionConfiguredEvent("1234","67e55044-10b1-426f-9247-bb680e5fe0c8","codex-mini-latest");
+        var json = JsonSerializer.Serialize(ev);
+        Assert.Equal("{\"type\":\"session_configured\",\"SessionId\":\"67e55044-10b1-426f-9247-bb680e5fe0c8\",\"Model\":\"codex-mini-latest\",\"Id\":\"1234\"}", json);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/ExecEnvTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ExecEnvTests.cs
@@ -92,4 +92,21 @@ public class ExecEnvTests
         Assert.Equal(new[]{"ONLY_VAR"}, env.Keys.ToArray());
         Assert.Equal("yes", env["ONLY_VAR"]);
     }
+
+    [Fact]
+    public void DuplicateVariablesUseLastValue()
+    {
+        var vars = new List<KeyValuePair<string,string>>
+        {
+            new("PATH","/bin"),
+            new("PATH","/usr/bin")
+        };
+        var policy = new ShellEnvironmentPolicy
+        {
+            Inherit = ShellEnvironmentPolicyInherit.All,
+            IgnoreDefaultExcludes = true
+        };
+        var env = ExecEnv.CreateFrom(vars, policy);
+        Assert.Equal("/usr/bin", env["PATH"]);
+    }
 }

--- a/codex-dotnet/CodexCli.Tests/LoginCommandTests.cs
+++ b/codex-dotnet/CodexCli.Tests/LoginCommandTests.cs
@@ -1,0 +1,36 @@
+using CodexCli.Commands;
+using CodexCli.Util;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Xunit;
+
+public class LoginCommandTests
+{
+    [Fact]
+    public async Task UsesChatGptLoginWhenFlagProvided()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tmp);
+        Environment.SetEnvironmentVariable("CODEX_HOME", tmp);
+        Environment.SetEnvironmentVariable("HOME", tmp);
+        bool called = false;
+        LoginCommand.LoginWithChatGptAsync = (home, capture, env) =>
+        {
+            called = true;
+            File.WriteAllText(Path.Combine(tmp, "auth.json"), "{\"OPENAI_API_KEY\":\"k\"}");
+            return Task.FromResult("k");
+        };
+        var root = new RootCommand();
+        var cfgOpt = new Option<string?>("--config");
+        var cdOpt = new Option<string?>("--cd");
+        root.AddOption(cfgOpt);
+        root.AddOption(cdOpt);
+        root.AddCommand(LoginCommand.Create(cfgOpt, cdOpt));
+        var parser = new Parser(root);
+        await parser.InvokeAsync("login --chatgpt --token t --provider openai --api-key \"\"");
+        Assert.True(called);
+        LoginCommand.LoginWithChatGptAsync = ChatGptLogin.LoginAsync;
+        Environment.SetEnvironmentVariable("CODEX_HOME", null);
+        Environment.SetEnvironmentVariable("HOME", null);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/ModelClientAggregationTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ModelClientAggregationTests.cs
@@ -1,0 +1,29 @@
+using CodexCli.Models;
+using CodexCli.Util;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+public class ModelClientAggregationTests
+{
+    [Fact]
+    public async Task ResponseStreamAggregateAggregates()
+    {
+        var src = new ResponseStream();
+        _ = Task.Run(async () =>
+        {
+            src.Writer.TryWrite(new OutputItemDone(new MessageItem("assistant", new List<ContentItem>{ new("output_text", "he") })));        
+            await Task.Delay(1);
+            src.Writer.TryWrite(new OutputItemDone(new MessageItem("assistant", new List<ContentItem>{ new("output_text", "llo") })));        
+            await Task.Delay(1);
+            src.Writer.TryWrite(new Completed("x"));
+            src.Writer.Complete();
+        });
+        var list = new List<ResponseEvent>();
+        await foreach (var ev in src.Aggregate())
+            list.Add(ev);
+        Assert.Equal(2, list.Count);
+        Assert.Equal("hello", ((MessageItem)((OutputItemDone)list[0]).Item).Content[0].Text);
+        Assert.IsType<Completed>(list[1]);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/ProtoCommandTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ProtoCommandTests.cs
@@ -1,0 +1,30 @@
+using CodexCli.Commands;
+using CodexCli.Util;
+using System.Diagnostics;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using System.IO;
+using Xunit;
+
+public class ProtoCommandTests
+{
+    [Fact]
+    public async Task PrintsMethod()
+    {
+        var repo = GitUtils.GetRepoRoot(Directory.GetCurrentDirectory())!;
+        var psi = new ProcessStartInfo("dotnet", "run --project codex-dotnet/CodexCli proto")
+        {
+            WorkingDirectory = repo,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        var p = Process.Start(psi)!;
+        await p.StandardInput.WriteAsync("{\"method\":\"foo\"}\n");
+        p.StandardInput.Close();
+        var output = await p.StandardOutput.ReadToEndAsync();
+        p.WaitForExit();
+        Assert.Contains("method=foo", output);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/SafetyTests.cs
+++ b/codex-dotnet/CodexCli.Tests/SafetyTests.cs
@@ -1,0 +1,51 @@
+using CodexCli.Util;
+using CodexCli.ApplyPatch;
+using CodexCli.Commands;
+using CodexCli.Protocol;
+using Xunit;
+using System.Collections.Generic;
+using System.IO;
+
+public class SafetyTests
+{
+    private static ApplyPatchAction MakeAdd(string file)
+    {
+        return new ApplyPatchAction(new Dictionary<string, ApplyPatchFileChange>
+        {
+            [file] = new ApplyPatchFileChange { Kind = "add", Content = string.Empty }
+        });
+    }
+
+    [Fact]
+    public void AssessPatchSafety_AutoApproveForWritableRoots()
+    {
+        var cwd = Directory.GetCurrentDirectory();
+        var action = MakeAdd("inner.txt");
+        var result = Safety.AssessPatchSafety(action, ApprovalMode.OnFailure, new List<string>{"."}, cwd);
+        Assert.Equal(SafetyCheck.AutoApprove, result);
+    }
+
+    [Fact]
+    public void AssessPatchSafety_AskUserUnlessAllowListed()
+    {
+        var cwd = Directory.GetCurrentDirectory();
+        var action = MakeAdd("inner.txt");
+        var result = Safety.AssessPatchSafety(action, ApprovalMode.UnlessAllowListed, new List<string>{"."}, cwd);
+        Assert.Equal(SafetyCheck.AskUser, result);
+    }
+
+    [Fact]
+    public void AssessCommandSafety_BasicCases()
+    {
+        var approved = new HashSet<List<string>>();
+        var sandbox = new SandboxPolicy();
+        var ok = Safety.AssessCommandSafety(new List<string>{"ls"}, ApprovalMode.OnFailure, sandbox, approved);
+        Assert.Equal(SafetyCheck.AutoApprove, ok);
+
+        var deny = Safety.AssessCommandSafety(new List<string>{"rm"}, ApprovalMode.Never, sandbox, approved);
+        Assert.Equal(SafetyCheck.Reject, deny);
+
+        var ask = Safety.AssessCommandSafety(new List<string>{"foo"}, ApprovalMode.OnFailure, sandbox, approved);
+        Assert.Equal(SafetyCheck.AskUser, ask);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/SequenceEqualityComparerTests.cs
+++ b/codex-dotnet/CodexCli.Tests/SequenceEqualityComparerTests.cs
@@ -1,0 +1,14 @@
+using CodexCli.Util;
+using Xunit;
+using System.Collections.Generic;
+
+public class SequenceEqualityComparerTests
+{
+    [Fact]
+    public void HashSetDetectsEquivalentLists()
+    {
+        var set = new HashSet<IReadOnlyList<string>>(new SequenceEqualityComparer<string>());
+        set.Add(new List<string>{"ls","-l"});
+        Assert.Contains(new List<string>{"ls","-l"}, set, new SequenceEqualityComparer<string>());
+    }
+}

--- a/codex-dotnet/CodexCli/Commands/DebugCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/DebugCommand.cs
@@ -2,6 +2,8 @@ using System.CommandLine;
 using CodexCli.Config;
 using CodexCli.Util;
 
+// Ported from codex-rs/cli/src/debug_sandbox.rs
+
 namespace CodexCli.Commands;
 
 public static class DebugCommand

--- a/codex-dotnet/CodexCli/Commands/LoginCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/LoginCommand.cs
@@ -1,3 +1,4 @@
+// Ported from codex-rs/cli/src/login.rs (done)
 using System.CommandLine;
 using CodexCli.Config;
 using CodexCli.Util;
@@ -6,6 +7,8 @@ namespace CodexCli.Commands;
 
 public static class LoginCommand
 {
+    public static Func<string, bool, IDictionary<string, string>?, Task<string>> LoginWithChatGptAsync { get; set; } = ChatGptLogin.LoginAsync;
+
     public static Command Create(Option<string?> configOption, Option<string?> cdOption)
     {
         var overridesOpt = new Option<string[]>("-c") { AllowMultipleArgumentsPerToken = true, Description = "Config overrides" };
@@ -73,7 +76,7 @@ public static class LoginCommand
                 Console.WriteLine("Launching browser login...");
                 try
                 {
-                    apiKey = await ChatGptLogin.LoginAsync(EnvUtils.FindCodexHome(), false, envMap);
+                    apiKey = await LoginWithChatGptAsync(EnvUtils.FindCodexHome(), false, envMap);
                 }
                 catch (Exception ex)
                 {

--- a/codex-dotnet/CodexCli/Commands/ProtoCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/ProtoCommand.cs
@@ -1,6 +1,8 @@
 using System.CommandLine;
 using CodexCli.Config;
 
+// Ported from codex-rs/cli/src/proto.rs
+
 namespace CodexCli.Commands;
 
 public static class ProtoCommand

--- a/codex-dotnet/CodexCli/Config/AppConfig.cs
+++ b/codex-dotnet/CodexCli/Config/AppConfig.cs
@@ -1,3 +1,4 @@
+// Ported from codex-rs/core/src/config.rs (done)
 using CodexCli.Commands;
 using Tomlyn;
 using System.Linq;

--- a/codex-dotnet/CodexCli/Models/ResponseItem.cs
+++ b/codex-dotnet/CodexCli/Models/ResponseItem.cs
@@ -1,3 +1,4 @@
+// Ported from codex-rs/core/src/models.rs (response item schema)
 namespace CodexCli.Models;
 
 using System.Text.Json.Serialization;

--- a/codex-dotnet/CodexCli/Program.cs
+++ b/codex-dotnet/CodexCli/Program.cs
@@ -45,7 +45,6 @@ public class Program
         }
 
         var logLevel = EnvUtils.GetLogLevel(root.Parse(args).GetValueForOption(logLevelOption));
-        Console.WriteLine($"Log level: {logLevel}");
         return await root.InvokeAsync(args);
     }
 }

--- a/codex-dotnet/CodexCli/Protocol/Event.cs
+++ b/codex-dotnet/CodexCli/Protocol/Event.cs
@@ -1,4 +1,4 @@
-
+// Rust analog: codex-rs/core/src/protocol.rs (done)
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs
+++ b/codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs
@@ -3,8 +3,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-/// Mirrors codex-rs/core/src/client.rs (streaming model client done; cancellation
-/// handling with OperationCanceledException parity implemented).
+/// Ported from codex-rs/core/src/client.rs (streaming model client with Ctrl+C parity)
 
 namespace CodexCli.Protocol;
 

--- a/codex-dotnet/CodexCli/Util/ChatCompletions.cs
+++ b/codex-dotnet/CodexCli/Util/ChatCompletions.cs
@@ -49,7 +49,7 @@ public static class ChatCompletions
         var aggregated = new ResponseStream();
         _ = Task.Run(async () =>
         {
-            await foreach (var ev in stream.Aggregate())
+            await foreach (var ev in ChatCompletions.Aggregate((IAsyncEnumerable<ResponseEvent>)stream))
                 aggregated.Writer.TryWrite(ev);
             aggregated.Writer.Complete();
         });

--- a/codex-dotnet/CodexCli/Util/ChatCompletions.cs
+++ b/codex-dotnet/CodexCli/Util/ChatCompletions.cs
@@ -1,0 +1,59 @@
+using CodexCli.Models;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace CodexCli.Util;
+
+// Ported from codex-rs/core/src/chat_completions.rs aggregator (done)
+public static class ChatCompletions
+{
+    public static async IAsyncEnumerable<ResponseEvent> Aggregate(
+        this IAsyncEnumerable<ResponseEvent> source,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancel = default)
+    {
+        string cumulative = string.Empty;
+        Completed? pending = null;
+        await foreach (var ev in source.WithCancellation(cancel))
+        {
+            if (pending != null)
+            {
+                yield return pending;
+                pending = null;
+            }
+            switch (ev)
+            {
+                case OutputItemDone { Item: MessageItem msg } when msg.Role == "assistant":
+                    var text = msg.Content.Count > 0 ? msg.Content[0].Text : string.Empty;
+                    cumulative += text;
+                    continue;
+                case Completed c:
+                    if (!string.IsNullOrEmpty(cumulative))
+                    {
+                        var item = new MessageItem("assistant",
+                            new List<ContentItem>{ new("output_text", cumulative) });
+                        cumulative = string.Empty;
+                        yield return new OutputItemDone(item);
+                        pending = c;
+                        continue;
+                    }
+                    break;
+            }
+            yield return ev;
+        }
+        if (pending != null)
+            yield return pending;
+    }
+
+    public static ResponseStream Aggregate(this ResponseStream stream)
+    {
+        var aggregated = new ResponseStream();
+        _ = Task.Run(async () =>
+        {
+            await foreach (var ev in stream.Aggregate())
+                aggregated.Writer.TryWrite(ev);
+            aggregated.Writer.Complete();
+        });
+        return aggregated;
+    }
+}
+

--- a/codex-dotnet/CodexCli/Util/ChatGptLogin.cs
+++ b/codex-dotnet/CodexCli/Util/ChatGptLogin.cs
@@ -1,3 +1,4 @@
+// Ported from codex-rs/login/src/lib.rs (done)
 using System.Diagnostics;
 using System.ComponentModel;
 using System.Text.Json;

--- a/codex-dotnet/CodexCli/Util/Codex.cs
+++ b/codex-dotnet/CodexCli/Util/Codex.cs
@@ -1,0 +1,38 @@
+// Rust analog: codex-rs/core/src/codex.rs (partial)
+// Ported from codex-rs/core/src/codex.rs spawn interface (partial)
+using CodexCli.Protocol;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace CodexCli.Util;
+
+public class Codex
+{
+    private readonly IAsyncEnumerator<Event> _enumerator;
+    private readonly CancellationTokenSource _ctrlC;
+
+    private Codex(IAsyncEnumerator<Event> enumerator, CancellationTokenSource ctrlC)
+    {
+        _enumerator = enumerator;
+        _ctrlC = ctrlC;
+    }
+
+    public static async Task<(Codex Codex, string SessionId)> SpawnAsync(
+        string prompt,
+        OpenAIClient client,
+        string model,
+        Func<string, OpenAIClient, string, CancellationToken, IAsyncEnumerable<Event>>? agent = null)
+    {
+        var (stream, sc, cts) = await CodexWrapper.InitCodexAsync(prompt, client, model, agent);
+        return (new Codex(stream.GetAsyncEnumerator(cts.Token), cts), sc.Id);
+    }
+
+    public async Task<Event?> NextEventAsync()
+    {
+        if (await _enumerator.MoveNextAsync())
+            return _enumerator.Current;
+        return null;
+    }
+
+    public void Cancel() => _ctrlC.Cancel();
+}

--- a/codex-dotnet/CodexCli/Util/CodexErr.cs
+++ b/codex-dotnet/CodexCli/Util/CodexErr.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Net;
+
+namespace CodexCli.Util;
+
+// Ported from codex-rs/core/src/error.rs (done)
+public enum SandboxErr
+{
+    Denied,
+    SeccompInstall,
+    SeccompBackend,
+    Timeout,
+    Signal,
+    LandlockRestrict,
+}
+
+public class EnvVarError : Exception
+{
+    public string Var { get; }
+    public string? Instructions { get; }
+
+    public EnvVarError(string var, string? instructions = null)
+        : base($"Missing environment variable: `{var}`." + (instructions != null ? $" {instructions}" : string.Empty))
+    {
+        Var = var;
+        Instructions = instructions;
+    }
+}
+
+public class CodexException : Exception
+{
+    private CodexException(string message) : base(message) { }
+    private CodexException(string message, Exception inner) : base(message, inner) { }
+
+    public static CodexException Stream(string msg) => new($"stream disconnected before completion: {msg}");
+    public static CodexException Timeout() => new("timeout waiting for child process to exit");
+    public static CodexException Spawn() => new("spawn failed: child stdout/stderr not captured");
+    public static CodexException Interrupted() => new("interrupted (Ctrl-C)");
+    public static CodexException UnexpectedStatus(HttpStatusCode status, string body) => new($"unexpected status {status}: {body}");
+    public static CodexException RetryLimit(HttpStatusCode status) => new($"exceeded retry limit, last status: {status}");
+    public static CodexException InternalAgentDied() => new("internal error; agent loop died unexpectedly");
+    public static CodexException Sandbox(SandboxErr err) => new($"sandbox error: {err}");
+    public static CodexException LandlockSandboxExecutableNotProvided() => new("codex-linux-sandbox was required but not provided");
+
+    public static CodexException Io(Exception inner) => new("io error", inner);
+    public static CodexException Reqwest(Exception inner) => new("http error", inner);
+    public static CodexException Json(Exception inner) => new("json error", inner);
+    public static CodexException EnvVar(EnvVarError err) => new(err.Message, err);
+}

--- a/codex-dotnet/CodexCli/Util/CodexWrapper.cs
+++ b/codex-dotnet/CodexCli/Util/CodexWrapper.cs
@@ -1,12 +1,33 @@
+// Rust analog: codex-rs/core/src/codex_wrapper.rs (done)
 using CodexCli.Protocol;
+using System.Collections.Generic;
+using System.Threading;
 
 namespace CodexCli.Util;
 
 public static class CodexWrapper
 {
-    public static async Task<IAsyncEnumerable<Event>> InitCodexAsync(string prompt, OpenAIClient client, string model)
+    public static async Task<(IAsyncEnumerable<Event> Stream, SessionConfiguredEvent SessionEvent, CancellationTokenSource CtrlC)>
+        InitCodexAsync(string prompt, OpenAIClient client, string model,
+            Func<string, OpenAIClient, string, CancellationToken, IAsyncEnumerable<Event>>? agent = null)
     {
-        // For now just forward to RealCodexAgent
-        return RealCodexAgent.RunAsync(prompt, client, model, null, Array.Empty<string>());
+        var cts = new CancellationTokenSource();
+        var events = agent != null
+            ? agent(prompt, client, model, cts.Token)
+            : RealCodexAgent.RunAsync(prompt, client, model, null, Array.Empty<string>(), cts.Token);
+
+        var enumerator = events.GetAsyncEnumerator(cts.Token);
+        if (!await enumerator.MoveNextAsync())
+            throw new InvalidOperationException("expected SessionConfigured event");
+        if (enumerator.Current is not SessionConfiguredEvent sc)
+            throw new InvalidOperationException($"expected SessionConfigured but got {enumerator.Current.GetType().Name}");
+
+        async IAsyncEnumerable<Event> Remainder([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancel = default)
+        {
+            while (await enumerator.MoveNextAsync())
+                yield return enumerator.Current;
+        }
+
+        return (Remainder(cts.Token), sc, cts);
     }
 }

--- a/codex-dotnet/CodexCli/Util/ExecEnv.cs
+++ b/codex-dotnet/CodexCli/Util/ExecEnv.cs
@@ -11,14 +11,19 @@ public static class ExecEnv
 {
     public static Dictionary<string,string> Create(ShellEnvironmentPolicy policy)
     {
-        IEnumerable<KeyValuePair<string,string>> vars = Environment.GetEnvironmentVariables()
-            .Cast<DictionaryEntry>().ToDictionary(d => (string)d.Key, d => (string)d.Value);
+        var vars = new List<KeyValuePair<string,string>>();
+        foreach (DictionaryEntry de in Environment.GetEnvironmentVariables())
+        {
+            vars.Add(new KeyValuePair<string,string>((string)de.Key, (string)de.Value));
+        }
         return CreateFrom(vars, policy);
     }
 
     public static Dictionary<string,string> CreateFrom(IEnumerable<KeyValuePair<string,string>> vars, ShellEnvironmentPolicy policy)
     {
-        var varsMap = new Dictionary<string,string>(vars, StringComparer.OrdinalIgnoreCase);
+        var varsMap = new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kv in vars)
+            varsMap[kv.Key] = kv.Value;
 
         Dictionary<string,string> map = policy.Inherit switch
         {

--- a/codex-dotnet/CodexCli/Util/ExecPolicy.cs
+++ b/codex-dotnet/CodexCli/Util/ExecPolicy.cs
@@ -1,3 +1,4 @@
+// Ported from codex-rs/execpolicy/src/lib.rs default policy loader
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 

--- a/codex-dotnet/CodexCli/Util/JsonToToml.cs
+++ b/codex-dotnet/CodexCli/Util/JsonToToml.cs
@@ -4,6 +4,9 @@ using Tomlyn;
 
 namespace CodexCli.Util;
 
+/// <summary>
+/// C# port of codex-rs/mcp-server/src/json_to_toml.rs (done).
+/// </summary>
 public static class JsonToToml
 {
     public static string ConvertToToml(JsonElement element)

--- a/codex-dotnet/CodexCli/Util/McpEventStream.cs
+++ b/codex-dotnet/CodexCli/Util/McpEventStream.cs
@@ -1,3 +1,4 @@
+// Ported from codex-rs/mcp-server/src/message_processor.rs SSE helpers
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/codex-dotnet/CodexCli/Util/ModelClient.cs
+++ b/codex-dotnet/CodexCli/Util/ModelClient.cs
@@ -43,6 +43,6 @@ public class ModelClient
             }
             stream.Writer.Complete();
         });
-        return stream;
+        return ChatCompletions.Aggregate(stream);
     }
 }

--- a/codex-dotnet/CodexCli/Util/RolloutRecorder.cs
+++ b/codex-dotnet/CodexCli/Util/RolloutRecorder.cs
@@ -1,3 +1,4 @@
+// Ported from codex-rs/core/src/rollout.rs (persistence logic)
 using System.Text.Json;
 using CodexCli.Config;
 using CodexCli.Models;

--- a/codex-dotnet/CodexCli/Util/SequenceEqualityComparer.cs
+++ b/codex-dotnet/CodexCli/Util/SequenceEqualityComparer.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CodexCli.Util;
+
+/// <summary>
+/// Helper comparer to compare sequences by value.
+/// Mirrors Hash implementation for Vec<T> in Rust when storing
+/// approved commands in ExecCommand safety checks.
+/// </summary>
+public class SequenceEqualityComparer<T> : IEqualityComparer<IReadOnlyList<T>>
+{
+    public bool Equals(IReadOnlyList<T>? x, IReadOnlyList<T>? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null || y is null || x.Count != y.Count) return false;
+        return x.SequenceEqual(y);
+    }
+
+    public int GetHashCode(IReadOnlyList<T> obj)
+    {
+        unchecked
+        {
+            int hash = 17;
+            foreach (var item in obj)
+                hash = hash * 31 + (item?.GetHashCode() ?? 0);
+            return hash;
+        }
+    }
+}

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -1,3 +1,4 @@
+// C# port: aggregator implemented in `codex-dotnet/CodexCli/Util/ChatCompletions.cs` (done)
 use std::time::Duration;
 
 use bytes::Bytes;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1,3 +1,4 @@
+// C# partial port: codex-dotnet/CodexCli/Util/Codex.cs
 // Poisoned mutex should fail the program
 #![allow(clippy::unwrap_used)]
 

--- a/codex-rs/core/src/codex_wrapper.rs
+++ b/codex-rs/core/src/codex_wrapper.rs
@@ -1,3 +1,4 @@
+// C# port implemented in codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 use std::sync::Arc;
 
 use crate::Codex;

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1,3 +1,4 @@
+// C# port implemented in codex-dotnet/CodexCli/Config/AppConfig.cs (done)
 use crate::config_profile::ConfigProfile;
 use crate::config_types::History;
 use crate::config_types::McpServerConfig;

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -1,3 +1,4 @@
+// C# port in `codex-dotnet/CodexCli/Util/CodexErr.cs` (done)
 use reqwest::StatusCode;
 use serde_json;
 use std::io;

--- a/codex-rs/core/src/models.rs
+++ b/codex-rs/core/src/models.rs
@@ -1,3 +1,4 @@
+// C# port: codex-dotnet/CodexCli/Models/ResponseItem.cs
 use std::collections::HashMap;
 
 use base64::Engine;

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -1,4 +1,5 @@
 //! Defines the protocol for a Codex session between a client and an agent.
+//! C# port implemented in `codex-dotnet/CodexCli/Protocol/Event.cs` (done)
 //!
 //! Uses a SQ (Submission Queue) / EQ (Event Queue) pattern to asynchronously communicate
 //! between user and agent.

--- a/codex-rs/core/src/rollout.rs
+++ b/codex-rs/core/src/rollout.rs
@@ -2,7 +2,7 @@
 //! [`ResponseItem`] objects exchanged during a session – to disk so that
 //! sessions can be replayed or inspected later (mirrors the behaviour of the
 //! upstream TypeScript implementation).
-// C# equivalent in `codex-dotnet/CodexCli/Commands/ReplayCommand.cs` (json, messages-only and follow parity tested)
+// C# equivalents: `codex-dotnet/CodexCli/Util/RolloutRecorder.cs` and `codex-dotnet/CodexCli/Commands/ReplayCommand.cs`
 
 use std::fs::File;
 use std::fs::{self};

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -1,3 +1,4 @@
+// C# port: codex-dotnet/CodexCli/Util/Safety.cs (done)
 use std::collections::HashSet;
 use std::path::Component;
 use std::path::Path;

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -1,4 +1,4 @@
-// C# port: codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety integrated)
+// C# port: codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 mod cli;
 mod event_processor;
 

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -1,3 +1,4 @@
+// C# port: codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial)
 mod cli;
 mod event_processor;
 

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -1,4 +1,4 @@
-// C# port: codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial)
+// C# port: codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety integrated)
 mod cli;
 mod event_processor;
 

--- a/codex-rs/execpolicy/src/lib.rs
+++ b/codex-rs/execpolicy/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
+// C# port implemented in codex-dotnet/CodexCli/Util/ExecPolicy.cs (done)
 #[macro_use]
 extern crate starlark;
 

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -1,3 +1,4 @@
+// C# port implemented in codex-dotnet/CodexCli/Util/ChatGptLogin.cs (done)
 use chrono::DateTime;
 use chrono::Utc;
 use serde::Deserialize;

--- a/codex-rs/mcp-server/src/json_to_toml.rs
+++ b/codex-rs/mcp-server/src/json_to_toml.rs
@@ -1,3 +1,4 @@
+// C# port implemented in codex-dotnet/CodexCli/Util/JsonToToml.cs (done)
 use serde_json::Value as JsonValue;
 use toml::Value as TomlValue;
 

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -1,6 +1,7 @@
-// C# port implemented in `codex-dotnet/CodexCli/Util/McpServer.cs` (ping,
-// event, watch-events, logging set-level, messages add/clear,
-// resource write/update/subscribe/remove and prompt/root add/remove parity tested)
+// C# ports implemented in `codex-dotnet/CodexCli/Util/McpServer.cs` and
+// `codex-dotnet/CodexCli/Util/McpEventStream.cs` (ping, event, watch-events,
+// logging set-level, messages add/clear, resource write/update/subscribe/remove
+// and prompt/root add/remove parity tested)
 use std::path::PathBuf;
 
 use crate::codex_tool_config::CodexToolCallParam;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -1,7 +1,7 @@
 // C# version implemented in `codex-dotnet/CodexCli/Interactive/InteractiveApp.cs`
 // Basic event streaming, approval callbacks, history log bridging and image
 // placeholder support with PNG/JPEG dimensions plus /log and /version commands
-// done.
+// and CodexWrapper session startup parity done.
 // Forbid accidental stdout/stderr writes in the *library* portion of the TUI.
 // The standalone `codex-tui` binary prints a short help message before the
 // alternate‑screen mode starts; that file opts‑out locally via `allow`.


### PR DESCRIPTION
## Summary
- port chat_completions.rs aggregator to C#
- integrate aggregation in ModelClient
- document progress in AGENTS.md
- note migration status in chat_completions.rs
- add aggregation unit tests

## Testing
- `dotnet test --no-build --filter ChatCompletionsAggregationTests`
- `dotnet test --no-build --filter FullyQualifiedName~ModelClientAggregationTests` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_b_6856a2880100832985c5ba1c8c3b0357