### PR TITLE
Add format_exec_output helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@
 - Ported `prompt.md` base instructions and `APPLY_PATCH_TOOL_INSTRUCTIONS` constant to C# with runtime loading.
 - Marked prompt and apply_patch instruction markdown files with port comments for traceability.
 - Ported `record_conversation_items` and `record_rollout_items` helpers as `Codex.RecordConversationItemsAsync` and `Codex.RecordRolloutItemsAsync` with new unit tests.
+- Ported `request_command_approval`, `request_patch_approval`, `notify_approval` and `add_approved_command` helpers as `Codex` methods with new unit tests.
 
 ## Rust to C# Mapping
 
@@ -119,6 +120,10 @@
 - codex-rs/core/src/codex.rs remove_task -> codex-dotnet/CodexCli/Util/Codex.cs RemoveTask (done)
 - codex-rs/core/src/codex.rs record_rollout_items -> codex-dotnet/CodexCli/Util/Codex.cs RecordRolloutItemsAsync (done)
 - codex-rs/core/src/codex.rs record_conversation_items -> codex-dotnet/CodexCli/Util/Codex.cs RecordConversationItemsAsync (done)
+- codex-rs/core/src/codex.rs request_command_approval -> codex-dotnet/CodexCli/Util/Codex.cs RequestCommandApproval (done)
+- codex-rs/core/src/codex.rs request_patch_approval -> codex-dotnet/CodexCli/Util/Codex.cs RequestPatchApproval (done)
+- codex-rs/core/src/codex.rs notify_approval -> codex-dotnet/CodexCli/Util/Codex.cs NotifyApproval (done)
+- codex-rs/core/src/codex.rs add_approved_command -> codex-dotnet/CodexCli/Util/Codex.cs AddApprovedCommand (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -151,5 +156,7 @@
 - Integrate Codex.InjectInput and GetPendingInput into session input workflow.
 - Integrate Codex.ResolvePath into command path handling.
 - Integrate Codex.SetTask and Codex.RemoveTask into session task workflow.
+- Integrate Codex.RequestCommandApproval and RequestPatchApproval into approval workflow.
+- Integrate Codex.NotifyApproval and AddApprovedCommand into approval workflow.
 - Integrate Codex.RecordConversationItemsAsync and RecordRolloutItemsAsync into session recording workflow.
 - Integrate Prompt base and apply_patch instructions loading into Prompt.GetFullInstructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@
 - Ported `notify_exec_command_begin`, `notify_exec_command_end`, and `notify_background_event` helpers as `Codex.NotifyExecCommandBegin`, `Codex.NotifyExecCommandEnd` and `Codex.NotifyBackgroundEvent` with new unit tests.
 - Ported `inject_input` and `get_pending_input` helpers as `Codex.InjectInput` and `Codex.GetPendingInput` with new unit tests.
 - Ported `resolve_path` helper as `Codex.ResolvePath` with new unit tests.
+- Ported `set_task` and `remove_task` helpers as `Codex.SetTask` and `Codex.RemoveTask` with new unit tests.
 
 ## Rust to C# Mapping
 
@@ -107,6 +108,8 @@
 - codex-rs/core/src/codex.rs notify_background_event -> codex-dotnet/CodexCli/Util/Codex.cs NotifyBackgroundEvent (done)
 - codex-rs/core/src/codex.rs inject_input -> codex-dotnet/CodexCli/Util/Codex.cs InjectInput (done)
 - codex-rs/core/src/codex.rs get_pending_input -> codex-dotnet/CodexCli/Util/Codex.cs GetPendingInput (done)
+- codex-rs/core/src/codex.rs set_task -> codex-dotnet/CodexCli/Util/Codex.cs SetTask (done)
+- codex-rs/core/src/codex.rs remove_task -> codex-dotnet/CodexCli/Util/Codex.cs RemoveTask (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -138,3 +141,4 @@
 - Integrate Codex.NotifyExecCommandBegin, NotifyExecCommandEnd and NotifyBackgroundEvent into session event workflow.
 - Integrate Codex.InjectInput and GetPendingInput into session input workflow.
 - Integrate Codex.ResolvePath into command path handling.
+- Integrate Codex.SetTask and Codex.RemoveTask into session task workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@
 - Ported `maybe_notify` helper as `Codex.MaybeNotify` with new unit test.
 - Ported `notify_exec_command_begin`, `notify_exec_command_end`, and `notify_background_event` helpers as `Codex.NotifyExecCommandBegin`, `Codex.NotifyExecCommandEnd` and `Codex.NotifyBackgroundEvent` with new unit tests.
 - Ported `inject_input` and `get_pending_input` helpers as `Codex.InjectInput` and `Codex.GetPendingInput` with new unit tests.
+- Ported `resolve_path` helper as `Codex.ResolvePath` with new unit tests.
 
 ## Rust to C# Mapping
 
@@ -94,6 +95,7 @@
 - codex-rs/core/src/safety.rs is_write_patch_constrained_to_writable_paths -> codex-dotnet/CodexCli/Util/Safety.cs IsWritePatchConstrainedToWritableRoots (done)
 - codex-rs/core/src/codex.rs to_exec_params -> codex-dotnet/CodexCli/Util/Codex.cs ToExecParams (done)
 - codex-rs/core/src/codex.rs parse_container_exec_arguments -> codex-dotnet/CodexCli/Util/Codex.cs TryParseContainerExecArguments (done)
+- codex-rs/core/src/codex.rs resolve_path -> codex-dotnet/CodexCli/Util/Codex.cs ResolvePath (done)
 - codex-rs/apply-patch/src/lib.rs print_summary -> codex-dotnet/CodexCli/ApplyPatch/PatchSummary.cs PrintSummary (done)
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAction (done)
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch_and_report -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyActionAndReport (done)
@@ -135,3 +137,4 @@
 - Integrate Codex.MaybeNotify into session event notifications.
 - Integrate Codex.NotifyExecCommandBegin, NotifyExecCommandEnd and NotifyBackgroundEvent into session event workflow.
 - Integrate Codex.InjectInput and GetPendingInput into session input workflow.
+- Integrate Codex.ResolvePath into command path handling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@
 - Ported `inject_input` and `get_pending_input` helpers as `Codex.InjectInput` and `Codex.GetPendingInput` with new unit tests.
 - Ported `resolve_path` helper as `Codex.ResolvePath` with new unit tests.
 - Ported `set_task` and `remove_task` helpers as `Codex.SetTask` and `Codex.RemoveTask` with new unit tests.
+- Ported `prompt.md` base instructions and `APPLY_PATCH_TOOL_INSTRUCTIONS` constant to C# with runtime loading.
 
 ## Rust to C# Mapping
 
@@ -87,6 +88,10 @@
 - codex-rs/core/src/safety.rs get_platform_sandbox -> codex-dotnet/CodexCli/Util/Safety.cs GetPlatformSandbox (done)
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
+- codex-rs/core/prompt.md -> codex-dotnet/CodexCli/prompt.md (done)
+- codex-rs/apply-patch/apply_patch_tool_instructions.md -> codex-dotnet/CodexCli/ApplyPatch/apply_patch_tool_instructions.md (done)
+- codex-rs/apply-patch/src/lib.rs APPLY_PATCH_TOOL_INSTRUCTIONS -> codex-dotnet/CodexCli/Models/Prompt.cs ApplyPatchToolInstructions (done)
+- codex-rs/core/src/client_common.rs BASE_INSTRUCTIONS -> codex-dotnet/CodexCli/Models/Prompt.cs BaseInstructions (done)
 - codex-rs/core/src/codex.rs format_exec_output -> codex-dotnet/CodexCli/Util/Codex.cs FormatExecOutput (done)
 - codex-rs/core/src/codex.rs get_writable_roots -> codex-dotnet/CodexCli/Util/Codex.cs GetWritableRoots (done)
 - codex-rs/core/src/codex.rs get_last_assistant_message_from_turn -> codex-dotnet/CodexCli/Util/Codex.cs GetLastAssistantMessageFromTurn (done)
@@ -142,3 +147,4 @@
 - Integrate Codex.InjectInput and GetPendingInput into session input workflow.
 - Integrate Codex.ResolvePath into command path handling.
 - Integrate Codex.SetTask and Codex.RemoveTask into session task workflow.
+- Integrate Prompt base and apply_patch instructions loading into Prompt.GetFullInstructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Migration Plan: Rust Codex CLI to .NET
 
 ## Completed Summary
+
 - Bootstrapped the .NET CLI with configuration loading, interactive mode, history management, sandbox enforcement and patch replay.
 - Ported provider management, API key handling and TUI widgets with approval workflow.
 - Added MCP client/server support with SSE events and cross-language tests.
@@ -30,7 +31,10 @@
 - Connected ChatGptLogin into LoginCommand with injectable delegate and added new unit test.
 - Ported debug sandbox and proto commands with a new ProtoCommand unit test.
 - Implemented MCP event streaming helpers (McpEventStream) and added watch-events tests.
+- Ported `format_exec_output` helper as `Codex.FormatExecOutput` with new unit test.
+
 ## Rust to C# Mapping
+
 - codex-rs/tui/src/exec_command.rs -> codex-dotnet/CodexCli/Util/ExecCommandUtils.cs (done)
 - codex-rs/core/src/is_safe_command.rs -> codex-dotnet/CodexCli/Util/SafeCommand.cs (done)
 - codex-rs/core/src/exec.rs -> codex-dotnet/CodexCli/Util/ExecRunner.cs (done)
@@ -65,14 +69,16 @@
 - codex-rs/core/src/safety.rs -> codex-dotnet/CodexCli/Util/Safety.cs (done)
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
+- codex-rs/core/src/codex.rs format_exec_output -> codex-dotnet/CodexCli/Util/Codex.cs FormatExecOutput (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
- - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
+- codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
 - codex-rs/core/src/models.rs -> codex-dotnet/CodexCli/Models/ResponseItem.cs (done)
 - codex-rs/core/src/rollout.rs -> codex-dotnet/CodexCli/Util/RolloutRecorder.cs and Commands/ReplayCommand.cs (done)
 - codex-rs/tui/src/lib.rs -> codex-dotnet/CodexCli/Interactive/InteractiveApp.cs (done)
 
 ## TODO
+
 - Integrate newly ported utilities throughout CLI commands and finalize SSE handling.
 - Expand CLI and cross-language parity tests and fix flakes, including chat aggregation.
 - Resolve exec parity test failures by aligning provider configuration between implementations.
@@ -83,3 +89,4 @@
 - Port remaining Codex session workflow (submission loop, rollout persistence) to .NET.
 - Expand ResponseItem coverage with integration tests for new event types.
 - Wire DebugCommand and ProtoCommand into parity tests and CLI workflows.
+- Integrate Codex.FormatExecOutput into ExecCommand parity tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 - Implemented MCP event streaming helpers (McpEventStream) and added watch-events tests.
 - Ported `format_exec_output` helper as `Codex.FormatExecOutput` with new unit test.
 - Ported `get_writable_roots` helper as `Codex.GetWritableRoots` with new unit test.
+- Ported `get_last_assistant_message_from_turn` and `record_conversation_history` helpers as `Codex` methods with new unit tests.
 
 ## Rust to C# Mapping
 
@@ -72,6 +73,8 @@
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
 - codex-rs/core/src/codex.rs format_exec_output -> codex-dotnet/CodexCli/Util/Codex.cs FormatExecOutput (done)
 - codex-rs/core/src/codex.rs get_writable_roots -> codex-dotnet/CodexCli/Util/Codex.cs GetWritableRoots (done)
+- codex-rs/core/src/codex.rs get_last_assistant_message_from_turn -> codex-dotnet/CodexCli/Util/Codex.cs GetLastAssistantMessageFromTurn (done)
+- codex-rs/core/src/codex.rs record_conversation_history -> codex-dotnet/CodexCli/Util/Codex.cs RecordConversationHistory (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -93,3 +96,4 @@
 - Wire DebugCommand and ProtoCommand into parity tests and CLI workflows.
 - Integrate Codex.FormatExecOutput into ExecCommand parity tests.
 - Integrate Codex.GetWritableRoots into spawn workflow.
+- Integrate Codex.GetLastAssistantMessageFromTurn and RecordConversationHistory into conversation logic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@
 - Ported `set_task` and `remove_task` helpers as `Codex.SetTask` and `Codex.RemoveTask` with new unit tests.
 - Ported `prompt.md` base instructions and `APPLY_PATCH_TOOL_INSTRUCTIONS` constant to C# with runtime loading.
 - Marked prompt and apply_patch instruction markdown files with port comments for traceability.
+- Ported `record_conversation_items` and `record_rollout_items` helpers as `Codex.RecordConversationItemsAsync` and `Codex.RecordRolloutItemsAsync` with new unit tests.
 
 ## Rust to C# Mapping
 
@@ -116,6 +117,8 @@
 - codex-rs/core/src/codex.rs get_pending_input -> codex-dotnet/CodexCli/Util/Codex.cs GetPendingInput (done)
 - codex-rs/core/src/codex.rs set_task -> codex-dotnet/CodexCli/Util/Codex.cs SetTask (done)
 - codex-rs/core/src/codex.rs remove_task -> codex-dotnet/CodexCli/Util/Codex.cs RemoveTask (done)
+- codex-rs/core/src/codex.rs record_rollout_items -> codex-dotnet/CodexCli/Util/Codex.cs RecordRolloutItemsAsync (done)
+- codex-rs/core/src/codex.rs record_conversation_items -> codex-dotnet/CodexCli/Util/Codex.cs RecordConversationItemsAsync (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -148,4 +151,5 @@
 - Integrate Codex.InjectInput and GetPendingInput into session input workflow.
 - Integrate Codex.ResolvePath into command path handling.
 - Integrate Codex.SetTask and Codex.RemoveTask into session task workflow.
+- Integrate Codex.RecordConversationItemsAsync and RecordRolloutItemsAsync into session recording workflow.
 - Integrate Prompt base and apply_patch instructions loading into Prompt.GetFullInstructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@
 - Ported `format_exec_output` helper as `Codex.FormatExecOutput` with new unit test.
 - Ported `get_writable_roots` helper as `Codex.GetWritableRoots` with new unit test.
 - Ported `get_last_assistant_message_from_turn` and `record_conversation_history` helpers as `Codex` methods with new unit tests.
+- Ported `convert_apply_patch_to_protocol` helper as `Codex.ConvertApplyPatchToProtocol` with unit, integration and CLI tests.
 
 ## Rust to C# Mapping
 
@@ -75,6 +76,7 @@
 - codex-rs/core/src/codex.rs get_writable_roots -> codex-dotnet/CodexCli/Util/Codex.cs GetWritableRoots (done)
 - codex-rs/core/src/codex.rs get_last_assistant_message_from_turn -> codex-dotnet/CodexCli/Util/Codex.cs GetLastAssistantMessageFromTurn (done)
 - codex-rs/core/src/codex.rs record_conversation_history -> codex-dotnet/CodexCli/Util/Codex.cs RecordConversationHistory (done)
+- codex-rs/core/src/codex.rs convert_apply_patch_to_protocol -> codex-dotnet/CodexCli/Util/Codex.cs ConvertApplyPatchToProtocol (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -97,3 +99,4 @@
 - Integrate Codex.FormatExecOutput into ExecCommand parity tests.
 - Integrate Codex.GetWritableRoots into spawn workflow.
 - Integrate Codex.GetLastAssistantMessageFromTurn and RecordConversationHistory into conversation logic.
+- Integrate Codex.ConvertApplyPatchToProtocol into ExecCommand patch handling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
 - Ported `to_exec_params` and `parse_container_exec_arguments` helpers as `Codex.ToExecParams` and `Codex.TryParseContainerExecArguments` with new unit tests.
 - Ported platform sandbox detection as `Safety.GetPlatformSandbox` with new unit test.
 - Ported `State.partial_clone` helper as `CodexState.PartialClone` with new unit test.
+- Ported `maybe_notify` helper as `Codex.MaybeNotify` with new unit test.
 
 ## Rust to C# Mapping
 
@@ -96,6 +97,7 @@
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch_and_report -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyActionAndReport (done)
 - codex-rs/apply-patch/src/lib.rs apply_patch -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAndReport (done)
 - codex-rs/core/src/codex.rs State.partial_clone -> codex-dotnet/CodexCli/Util/CodexState.cs PartialClone (done)
+- codex-rs/core/src/codex.rs maybe_notify -> codex-dotnet/CodexCli/Util/Codex.cs MaybeNotify (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -123,3 +125,4 @@
 - Integrate PatchSummary.PrintSummary into patch application workflow.
 - Integrate PatchApplier.ApplyActionAndReport into CLI patch workflows.
 - Integrate PatchApplier.ApplyAndReport into CLI patch workflows.
+- Integrate Codex.MaybeNotify into session event notifications.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@
 - Ported `apply_changes_from_apply_patch` and `apply_changes_from_apply_patch_and_report` as `PatchApplier.ApplyAction` and `PatchApplier.ApplyActionAndReport` with new unit tests.
 - Ported `apply_patch` helper as `PatchApplier.ApplyAndReport` with new unit, integration and CLI tests.
 - Ported `is_write_patch_constrained_to_writable_paths` helper as `Safety.IsWritePatchConstrainedToWritableRoots` with new unit test.
+- Ported `to_exec_params` and `parse_container_exec_arguments` helpers as `Codex.ToExecParams` and `Codex.TryParseContainerExecArguments` with new unit tests.
 
 ## Rust to C# Mapping
 
@@ -84,6 +85,8 @@
 - codex-rs/core/src/codex.rs convert_apply_patch_to_protocol -> codex-dotnet/CodexCli/Util/Codex.cs ConvertApplyPatchToProtocol (done)
 - codex-rs/core/src/codex.rs first_offending_path -> codex-dotnet/CodexCli/Util/Codex.cs FirstOffendingPath (done)
 - codex-rs/core/src/safety.rs is_write_patch_constrained_to_writable_paths -> codex-dotnet/CodexCli/Util/Safety.cs IsWritePatchConstrainedToWritableRoots (done)
+- codex-rs/core/src/codex.rs to_exec_params -> codex-dotnet/CodexCli/Util/Codex.cs ToExecParams (done)
+- codex-rs/core/src/codex.rs parse_container_exec_arguments -> codex-dotnet/CodexCli/Util/Codex.cs TryParseContainerExecArguments (done)
 - codex-rs/apply-patch/src/lib.rs print_summary -> codex-dotnet/CodexCli/ApplyPatch/PatchSummary.cs PrintSummary (done)
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAction (done)
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch_and_report -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyActionAndReport (done)
@@ -111,6 +114,7 @@
 - Integrate Codex.GetWritableRoots into spawn workflow.
 - Integrate Codex.GetLastAssistantMessageFromTurn and RecordConversationHistory into conversation logic.
 - Integrate Codex.ConvertApplyPatchToProtocol into ExecCommand patch handling.
+- Integrate Codex.ToExecParams and TryParseContainerExecArguments into ExecCommand function call handling.
 - Integrate PatchSummary.PrintSummary into patch application workflow.
 - Integrate PatchApplier.ApplyActionAndReport into CLI patch workflows.
 - Integrate PatchApplier.ApplyAndReport into CLI patch workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@
 - Ported platform sandbox detection as `Safety.GetPlatformSandbox` with new unit test.
 - Ported `State.partial_clone` helper as `CodexState.PartialClone` with new unit test.
 - Ported `maybe_notify` helper as `Codex.MaybeNotify` with new unit test.
+- Ported `notify_exec_command_begin`, `notify_exec_command_end`, and `notify_background_event` helpers as `Codex.NotifyExecCommandBegin`, `Codex.NotifyExecCommandEnd` and `Codex.NotifyBackgroundEvent` with new unit tests.
 
 ## Rust to C# Mapping
 
@@ -98,6 +99,9 @@
 - codex-rs/apply-patch/src/lib.rs apply_patch -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAndReport (done)
 - codex-rs/core/src/codex.rs State.partial_clone -> codex-dotnet/CodexCli/Util/CodexState.cs PartialClone (done)
 - codex-rs/core/src/codex.rs maybe_notify -> codex-dotnet/CodexCli/Util/Codex.cs MaybeNotify (done)
+- codex-rs/core/src/codex.rs notify_exec_command_begin -> codex-dotnet/CodexCli/Util/Codex.cs NotifyExecCommandBegin (done)
+- codex-rs/core/src/codex.rs notify_exec_command_end -> codex-dotnet/CodexCli/Util/Codex.cs NotifyExecCommandEnd (done)
+- codex-rs/core/src/codex.rs notify_background_event -> codex-dotnet/CodexCli/Util/Codex.cs NotifyBackgroundEvent (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -126,3 +130,4 @@
 - Integrate PatchApplier.ApplyActionAndReport into CLI patch workflows.
 - Integrate PatchApplier.ApplyAndReport into CLI patch workflows.
 - Integrate Codex.MaybeNotify into session event notifications.
+- Integrate Codex.NotifyExecCommandBegin, NotifyExecCommandEnd and NotifyBackgroundEvent into session event workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 - Ported `get_last_assistant_message_from_turn` and `record_conversation_history` helpers as `Codex` methods with new unit tests.
 - Ported `convert_apply_patch_to_protocol` helper as `Codex.ConvertApplyPatchToProtocol` with unit, integration and CLI tests.
 - Ported `print_summary` helper as `PatchSummary.PrintSummary` with new unit and CLI tests.
+- Ported `first_offending_path` helper as `Codex.FirstOffendingPath` with new unit tests.
 
 ## Rust to C# Mapping
 
@@ -78,6 +79,7 @@
 - codex-rs/core/src/codex.rs get_last_assistant_message_from_turn -> codex-dotnet/CodexCli/Util/Codex.cs GetLastAssistantMessageFromTurn (done)
 - codex-rs/core/src/codex.rs record_conversation_history -> codex-dotnet/CodexCli/Util/Codex.cs RecordConversationHistory (done)
 - codex-rs/core/src/codex.rs convert_apply_patch_to_protocol -> codex-dotnet/CodexCli/Util/Codex.cs ConvertApplyPatchToProtocol (done)
+- codex-rs/core/src/codex.rs first_offending_path -> codex-dotnet/CodexCli/Util/Codex.cs FirstOffendingPath (done)
 - codex-rs/apply-patch/src/lib.rs print_summary -> codex-dotnet/CodexCli/ApplyPatch/PatchSummary.cs PrintSummary (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 - Ported debug sandbox and proto commands with a new ProtoCommand unit test.
 - Implemented MCP event streaming helpers (McpEventStream) and added watch-events tests.
 - Ported `format_exec_output` helper as `Codex.FormatExecOutput` with new unit test.
+- Ported `get_writable_roots` helper as `Codex.GetWritableRoots` with new unit test.
 
 ## Rust to C# Mapping
 
@@ -70,6 +71,7 @@
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
 - codex-rs/core/src/codex.rs format_exec_output -> codex-dotnet/CodexCli/Util/Codex.cs FormatExecOutput (done)
+- codex-rs/core/src/codex.rs get_writable_roots -> codex-dotnet/CodexCli/Util/Codex.cs GetWritableRoots (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -90,3 +92,4 @@
 - Expand ResponseItem coverage with integration tests for new event types.
 - Wire DebugCommand and ProtoCommand into parity tests and CLI workflows.
 - Integrate Codex.FormatExecOutput into ExecCommand parity tests.
+- Integrate Codex.GetWritableRoots into spawn workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@
 - Ported `apply_patch` helper as `PatchApplier.ApplyAndReport` with new unit, integration and CLI tests.
 - Ported `is_write_patch_constrained_to_writable_paths` helper as `Safety.IsWritePatchConstrainedToWritableRoots` with new unit test.
 - Ported `to_exec_params` and `parse_container_exec_arguments` helpers as `Codex.ToExecParams` and `Codex.TryParseContainerExecArguments` with new unit tests.
+- Ported platform sandbox detection as `Safety.GetPlatformSandbox` with new unit test.
 
 ## Rust to C# Mapping
 
@@ -76,6 +77,8 @@
 - codex-rs/cli/src/debug_sandbox.rs -> codex-dotnet/CodexCli/Commands/DebugCommand.cs (done)
 - codex-rs/cli/src/proto.rs -> codex-dotnet/CodexCli/Commands/ProtoCommand.cs (done)
 - codex-rs/core/src/safety.rs -> codex-dotnet/CodexCli/Util/Safety.cs (done)
+- codex-rs/core/src/exec.rs SandboxType -> codex-dotnet/CodexCli/Protocol/SandboxType.cs (done)
+- codex-rs/core/src/safety.rs get_platform_sandbox -> codex-dotnet/CodexCli/Util/Safety.cs GetPlatformSandbox (done)
 - codex-rs/core/src/codex_wrapper.rs -> codex-dotnet/CodexCli/Util/CodexWrapper.cs (done)
 - codex-rs/core/src/protocol.rs -> codex-dotnet/CodexCli/Protocol/Event.cs (done)
 - codex-rs/core/src/codex.rs format_exec_output -> codex-dotnet/CodexCli/Util/Codex.cs FormatExecOutput (done)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@
 - Ported `is_write_patch_constrained_to_writable_paths` helper as `Safety.IsWritePatchConstrainedToWritableRoots` with new unit test.
 - Ported `to_exec_params` and `parse_container_exec_arguments` helpers as `Codex.ToExecParams` and `Codex.TryParseContainerExecArguments` with new unit tests.
 - Ported platform sandbox detection as `Safety.GetPlatformSandbox` with new unit test.
+- Ported `State.partial_clone` helper as `CodexState.PartialClone` with new unit test.
 
 ## Rust to C# Mapping
 
@@ -94,6 +95,7 @@
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAction (done)
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch_and_report -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyActionAndReport (done)
 - codex-rs/apply-patch/src/lib.rs apply_patch -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAndReport (done)
+- codex-rs/core/src/codex.rs State.partial_clone -> codex-dotnet/CodexCli/Util/CodexState.cs PartialClone (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 - Ported `get_writable_roots` helper as `Codex.GetWritableRoots` with new unit test.
 - Ported `get_last_assistant_message_from_turn` and `record_conversation_history` helpers as `Codex` methods with new unit tests.
 - Ported `convert_apply_patch_to_protocol` helper as `Codex.ConvertApplyPatchToProtocol` with unit, integration and CLI tests.
+- Ported `print_summary` helper as `PatchSummary.PrintSummary` with new unit and CLI tests.
 
 ## Rust to C# Mapping
 
@@ -77,6 +78,7 @@
 - codex-rs/core/src/codex.rs get_last_assistant_message_from_turn -> codex-dotnet/CodexCli/Util/Codex.cs GetLastAssistantMessageFromTurn (done)
 - codex-rs/core/src/codex.rs record_conversation_history -> codex-dotnet/CodexCli/Util/Codex.cs RecordConversationHistory (done)
 - codex-rs/core/src/codex.rs convert_apply_patch_to_protocol -> codex-dotnet/CodexCli/Util/Codex.cs ConvertApplyPatchToProtocol (done)
+- codex-rs/apply-patch/src/lib.rs print_summary -> codex-dotnet/CodexCli/ApplyPatch/PatchSummary.cs PrintSummary (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -100,3 +102,4 @@
 - Integrate Codex.GetWritableRoots into spawn workflow.
 - Integrate Codex.GetLastAssistantMessageFromTurn and RecordConversationHistory into conversation logic.
 - Integrate Codex.ConvertApplyPatchToProtocol into ExecCommand patch handling.
+- Integrate PatchSummary.PrintSummary into patch application workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
 - Ported `print_summary` helper as `PatchSummary.PrintSummary` with new unit and CLI tests.
 - Ported `first_offending_path` helper as `Codex.FirstOffendingPath` with new unit tests.
 - Ported `apply_changes_from_apply_patch` and `apply_changes_from_apply_patch_and_report` as `PatchApplier.ApplyAction` and `PatchApplier.ApplyActionAndReport` with new unit tests.
+- Ported `apply_patch` helper as `PatchApplier.ApplyAndReport` with new unit, integration and CLI tests.
 
 ## Rust to C# Mapping
 
@@ -84,6 +85,7 @@
 - codex-rs/apply-patch/src/lib.rs print_summary -> codex-dotnet/CodexCli/ApplyPatch/PatchSummary.cs PrintSummary (done)
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAction (done)
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch_and_report -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyActionAndReport (done)
+- codex-rs/apply-patch/src/lib.rs apply_patch -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAndReport (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -109,3 +111,4 @@
 - Integrate Codex.ConvertApplyPatchToProtocol into ExecCommand patch handling.
 - Integrate PatchSummary.PrintSummary into patch application workflow.
 - Integrate PatchApplier.ApplyActionAndReport into CLI patch workflows.
+- Integrate PatchApplier.ApplyAndReport into CLI patch workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@
 - Ported `resolve_path` helper as `Codex.ResolvePath` with new unit tests.
 - Ported `set_task` and `remove_task` helpers as `Codex.SetTask` and `Codex.RemoveTask` with new unit tests.
 - Ported `prompt.md` base instructions and `APPLY_PATCH_TOOL_INSTRUCTIONS` constant to C# with runtime loading.
+- Marked prompt and apply_patch instruction markdown files with port comments for traceability.
 
 ## Rust to C# Mapping
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
 - Ported `first_offending_path` helper as `Codex.FirstOffendingPath` with new unit tests.
 - Ported `apply_changes_from_apply_patch` and `apply_changes_from_apply_patch_and_report` as `PatchApplier.ApplyAction` and `PatchApplier.ApplyActionAndReport` with new unit tests.
 - Ported `apply_patch` helper as `PatchApplier.ApplyAndReport` with new unit, integration and CLI tests.
+- Ported `is_write_patch_constrained_to_writable_paths` helper as `Safety.IsWritePatchConstrainedToWritableRoots` with new unit test.
 
 ## Rust to C# Mapping
 
@@ -82,6 +83,7 @@
 - codex-rs/core/src/codex.rs record_conversation_history -> codex-dotnet/CodexCli/Util/Codex.cs RecordConversationHistory (done)
 - codex-rs/core/src/codex.rs convert_apply_patch_to_protocol -> codex-dotnet/CodexCli/Util/Codex.cs ConvertApplyPatchToProtocol (done)
 - codex-rs/core/src/codex.rs first_offending_path -> codex-dotnet/CodexCli/Util/Codex.cs FirstOffendingPath (done)
+- codex-rs/core/src/safety.rs is_write_patch_constrained_to_writable_paths -> codex-dotnet/CodexCli/Util/Safety.cs IsWritePatchConstrainedToWritableRoots (done)
 - codex-rs/apply-patch/src/lib.rs print_summary -> codex-dotnet/CodexCli/ApplyPatch/PatchSummary.cs PrintSummary (done)
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAction (done)
 - codex-rs/core/src/codex.rs apply_changes_from_apply_patch_and_report -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyActionAndReport (done)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@
 - Ported `convert_apply_patch_to_protocol` helper as `Codex.ConvertApplyPatchToProtocol` with unit, integration and CLI tests.
 - Ported `print_summary` helper as `PatchSummary.PrintSummary` with new unit and CLI tests.
 - Ported `first_offending_path` helper as `Codex.FirstOffendingPath` with new unit tests.
+- Ported `apply_changes_from_apply_patch` and `apply_changes_from_apply_patch_and_report` as `PatchApplier.ApplyAction` and `PatchApplier.ApplyActionAndReport` with new unit tests.
 
 ## Rust to C# Mapping
 
@@ -81,6 +82,8 @@
 - codex-rs/core/src/codex.rs convert_apply_patch_to_protocol -> codex-dotnet/CodexCli/Util/Codex.cs ConvertApplyPatchToProtocol (done)
 - codex-rs/core/src/codex.rs first_offending_path -> codex-dotnet/CodexCli/Util/Codex.cs FirstOffendingPath (done)
 - codex-rs/apply-patch/src/lib.rs print_summary -> codex-dotnet/CodexCli/ApplyPatch/PatchSummary.cs PrintSummary (done)
+- codex-rs/core/src/codex.rs apply_changes_from_apply_patch -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAction (done)
+- codex-rs/core/src/codex.rs apply_changes_from_apply_patch_and_report -> codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyActionAndReport (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -105,3 +108,4 @@
 - Integrate Codex.GetLastAssistantMessageFromTurn and RecordConversationHistory into conversation logic.
 - Integrate Codex.ConvertApplyPatchToProtocol into ExecCommand patch handling.
 - Integrate PatchSummary.PrintSummary into patch application workflow.
+- Integrate PatchApplier.ApplyActionAndReport into CLI patch workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@
 - Marked prompt and apply_patch instruction markdown files with port comments for traceability.
 - Ported `record_conversation_items` and `record_rollout_items` helpers as `Codex.RecordConversationItemsAsync` and `Codex.RecordRolloutItemsAsync` with new unit tests.
 - Ported `request_command_approval`, `request_patch_approval`, `notify_approval` and `add_approved_command` helpers as `Codex` methods with new unit tests.
+- Updated Prompt instruction loader to strip HTML comments so tests consume the same text as Rust.
 
 ## Rust to C# Mapping
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@
 - Ported `State.partial_clone` helper as `CodexState.PartialClone` with new unit test.
 - Ported `maybe_notify` helper as `Codex.MaybeNotify` with new unit test.
 - Ported `notify_exec_command_begin`, `notify_exec_command_end`, and `notify_background_event` helpers as `Codex.NotifyExecCommandBegin`, `Codex.NotifyExecCommandEnd` and `Codex.NotifyBackgroundEvent` with new unit tests.
+- Ported `inject_input` and `get_pending_input` helpers as `Codex.InjectInput` and `Codex.GetPendingInput` with new unit tests.
 
 ## Rust to C# Mapping
 
@@ -102,6 +103,8 @@
 - codex-rs/core/src/codex.rs notify_exec_command_begin -> codex-dotnet/CodexCli/Util/Codex.cs NotifyExecCommandBegin (done)
 - codex-rs/core/src/codex.rs notify_exec_command_end -> codex-dotnet/CodexCli/Util/Codex.cs NotifyExecCommandEnd (done)
 - codex-rs/core/src/codex.rs notify_background_event -> codex-dotnet/CodexCli/Util/Codex.cs NotifyBackgroundEvent (done)
+- codex-rs/core/src/codex.rs inject_input -> codex-dotnet/CodexCli/Util/Codex.cs InjectInput (done)
+- codex-rs/core/src/codex.rs get_pending_input -> codex-dotnet/CodexCli/Util/Codex.cs GetPendingInput (done)
 - codex-rs/core/src/codex.rs -> codex-dotnet/CodexCli/Util/Codex.cs (partial)
 - codex-rs/exec/src/lib.rs -> codex-dotnet/CodexCli/Commands/ExecCommand.cs (partial, safety and Ctrl+C integrated)
 - codex-rs/core/src/client.rs -> codex-dotnet/CodexCli/Protocol/RealCodexAgent.cs (done)
@@ -131,3 +134,4 @@
 - Integrate PatchApplier.ApplyAndReport into CLI patch workflows.
 - Integrate Codex.MaybeNotify into session event notifications.
 - Integrate Codex.NotifyExecCommandBegin, NotifyExecCommandEnd and NotifyBackgroundEvent into session event workflow.
+- Integrate Codex.InjectInput and GetPendingInput into session input workflow.

--- a/codex-dotnet/CodexCli.Tests/ApplyPatchCommandCliTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ApplyPatchCommandCliTests.cs
@@ -1,0 +1,30 @@
+using CodexCli.Commands;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Xunit;
+
+public class ApplyPatchCommandCliTests
+{
+    [Fact]
+    public async Task PatchCommandAppliesFile()
+    {
+        using var dir = new TempDir();
+        var patchPath = Path.Combine(dir.Path, "p.patch");
+        File.WriteAllText(patchPath, "*** Begin Patch\n*** Add File: foo.txt\n+hi\n*** End Patch");
+        var root = new RootCommand();
+        root.AddCommand(ApplyPatchCommand.Create());
+        var parser = new Parser(root);
+        var output = new StringWriter();
+        Console.SetOut(output);
+        await parser.InvokeAsync($"apply_patch {patchPath} --cwd {dir.Path}");
+        Assert.True(File.Exists(Path.Combine(dir.Path, "foo.txt")));
+        Assert.Contains("added foo.txt", output.ToString());
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+        public TempDir() { Directory.CreateDirectory(Path); }
+        public void Dispose() { Directory.Delete(Path, true); }
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/ApplyPatchCommandCliTests.cs
+++ b/codex-dotnet/CodexCli.Tests/ApplyPatchCommandCliTests.cs
@@ -18,7 +18,9 @@ public class ApplyPatchCommandCliTests
         Console.SetOut(output);
         await parser.InvokeAsync($"apply_patch {patchPath} --cwd {dir.Path}");
         Assert.True(File.Exists(Path.Combine(dir.Path, "foo.txt")));
-        Assert.Contains("added foo.txt", output.ToString());
+        var text = output.ToString();
+        Assert.Contains("Success. Updated the following files:", text);
+        Assert.Contains("A foo.txt", text);
     }
 
     private sealed class TempDir : IDisposable

--- a/codex-dotnet/CodexCli.Tests/CodexApprovalHelpersTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexApprovalHelpersTests.cs
@@ -1,0 +1,44 @@
+using CodexCli.ApplyPatch;
+using CodexCli.Util;
+using CodexCli.Protocol;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+public class CodexApprovalHelpersTests
+{
+    [Fact]
+    public async Task RequestCommandApproval_ReturnsEventAndCompletes()
+    {
+        var state = new CodexState();
+        var (task, ev) = Codex.RequestCommandApproval(state, "1", new List<string>{"ls"}, "/tmp", null);
+        Assert.True(state.PendingApprovals.ContainsKey("1"));
+        Assert.Equal(new[]{"ls"}, ev.Command);
+        Codex.NotifyApproval(state, "1", ReviewDecision.Approved);
+        var decision = await task;
+        Assert.Equal(ReviewDecision.Approved, decision);
+    }
+
+    [Fact]
+    public async Task RequestPatchApproval_ReturnsEventAndCompletes()
+    {
+        var changes = new Dictionary<string, ApplyPatchFileChange>{
+            ["a.txt"] = new ApplyPatchFileChange{ Kind = "add", Content = "" }
+        };
+        var action = new ApplyPatchAction(changes);
+        var state = new CodexState();
+        var (task, ev) = Codex.RequestPatchApproval(state, "2", action, null, null);
+        Assert.True(ev.PatchSummary.Contains("a.txt"));
+        Codex.NotifyApproval(state, "2", ReviewDecision.Denied);
+        var decision = await task;
+        Assert.Equal(ReviewDecision.Denied, decision);
+    }
+
+    [Fact]
+    public void AddApprovedCommand_AddsToSet()
+    {
+        var state = new CodexState();
+        Codex.AddApprovedCommand(state, new List<string>{"echo","hi"});
+        Assert.Single(state.ApprovedCommands);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexConvertApplyPatchToProtocolTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexConvertApplyPatchToProtocolTests.cs
@@ -1,0 +1,37 @@
+using CodexCli.ApplyPatch;
+using CodexCli.Protocol;
+using CodexCli.Util;
+using System.Collections.Generic;
+using Xunit;
+
+public class CodexConvertApplyPatchToProtocolTests
+{
+    [Fact]
+    public void ConvertsChanges()
+    {
+        var action = new ApplyPatchAction(new Dictionary<string, ApplyPatchFileChange>
+        {
+            ["/tmp/a.txt"] = new ApplyPatchFileChange { Kind = "add", Content = "hi\n" },
+            ["/tmp/b.txt"] = new ApplyPatchFileChange { Kind = "delete" },
+            ["/tmp/c.txt"] = new ApplyPatchFileChange { Kind = "update", UnifiedDiff = "+hi\n-context\n", MovePath = null }
+        });
+        var result = Codex.ConvertApplyPatchToProtocol(action);
+        Assert.IsType<AddFileChange>(result["/tmp/a.txt"]);
+        Assert.IsType<DeleteFileChange>(result["/tmp/b.txt"]);
+        Assert.IsType<UpdateFileChange>(result["/tmp/c.txt"]);
+        var upd = (UpdateFileChange)result["/tmp/c.txt"];
+        Assert.Equal("+hi\n-context\n", upd.UnifiedDiff);
+    }
+
+    [Fact]
+    public void ParsesAndConverts()
+    {
+        var argv = new [] { "apply_patch", "*** Begin Patch\n*** Add File: a.txt\n+hi\n*** End Patch" };
+        var res = ApplyPatchCommandParser.MaybeParseApplyPatchVerified(argv, "/tmp", out var action);
+        Assert.Equal(MaybeApplyPatchVerified.Body, res);
+        Assert.NotNull(action);
+        var dict = Codex.ConvertApplyPatchToProtocol(action!);
+        Assert.Single(dict);
+        Assert.Contains("/tmp/a.txt", dict.Keys);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexFirstOffendingPathTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexFirstOffendingPathTests.cs
@@ -1,0 +1,29 @@
+using CodexCli.ApplyPatch;
+using CodexCli.Util;
+using System.Collections.Generic;
+using Xunit;
+
+public class CodexFirstOffendingPathTests
+{
+    [Fact]
+    public void ReturnsNullWhenAllWritable()
+    {
+        var action = new ApplyPatchAction(new Dictionary<string, ApplyPatchFileChange>
+        {
+            ["file.txt"] = new ApplyPatchFileChange { Kind = "add", Content = "" }
+        });
+        var result = Codex.FirstOffendingPath(action, new List<string>{"/tmp"}, "/tmp");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void FindsOffendingPath()
+    {
+        var action = new ApplyPatchAction(new Dictionary<string, ApplyPatchFileChange>
+        {
+            ["/etc/passwd"] = new ApplyPatchFileChange { Kind = "delete" }
+        });
+        var result = Codex.FirstOffendingPath(action, new List<string>{"/tmp"}, "/tmp");
+        Assert.Equal("/etc/passwd", result);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexFormatExecOutputTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexFormatExecOutputTests.cs
@@ -1,5 +1,6 @@
 using CodexCli.Util;
 using System.Text.Json;
+using Xunit;
 
 public class CodexFormatExecOutputTests
 {

--- a/codex-dotnet/CodexCli.Tests/CodexFormatExecOutputTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexFormatExecOutputTests.cs
@@ -1,0 +1,17 @@
+using CodexCli.Util;
+using System.Text.Json;
+
+public class CodexFormatExecOutputTests
+{
+    [Fact]
+    public void FormatsJson()
+    {
+        var json = Codex.FormatExecOutput("hi", 0, TimeSpan.FromSeconds(1.23));
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("hi", root.GetProperty("output").GetString());
+        var meta = root.GetProperty("metadata");
+        Assert.Equal(0, meta.GetProperty("exit_code").GetInt32());
+        Assert.Equal(1.2, meta.GetProperty("duration_seconds").GetDouble(), 1);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexGetLastAssistantMessageFromTurnTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexGetLastAssistantMessageFromTurnTests.cs
@@ -1,0 +1,31 @@
+using CodexCli.Models;
+using CodexCli.Util;
+using System.Collections.Generic;
+using Xunit;
+
+public class CodexGetLastAssistantMessageFromTurnTests
+{
+    [Fact]
+    public void FindsAssistantText()
+    {
+        var responses = new List<ResponseItem>
+        {
+            new MessageItem("user", new List<ContentItem>{ new("output_text", "hi") }),
+            new MessageItem("assistant", new List<ContentItem>{ new("output_text", "first") }),
+            new MessageItem("assistant", new List<ContentItem>{ new("output_text", "second") })
+        };
+        var result = Codex.GetLastAssistantMessageFromTurn(responses);
+        Assert.Equal("second", result);
+    }
+
+    [Fact]
+    public void ReturnsNullWhenMissing()
+    {
+        var responses = new List<ResponseItem>
+        {
+            new MessageItem("user", new List<ContentItem>{ new("output_text", "hi") })
+        };
+        var result = Codex.GetLastAssistantMessageFromTurn(responses);
+        Assert.Null(result);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexGetWritableRootsTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexGetWritableRootsTests.cs
@@ -1,0 +1,25 @@
+using CodexCli.Util;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public class CodexGetWritableRootsTests
+{
+    [Fact]
+    public void IncludesCwd()
+    {
+        var cwd = "/tmp";
+        var roots = Codex.GetWritableRoots(cwd);
+        Assert.Contains(cwd, roots);
+    }
+
+    [Fact]
+    public void MacIncludesTempDir()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return;
+        var cwd = "/tmp";
+        var roots = Codex.GetWritableRoots(cwd);
+        Assert.Contains(Path.GetTempPath(), roots);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexInjectPendingInputTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexInjectPendingInputTests.cs
@@ -1,0 +1,39 @@
+using CodexCli.Util;
+using CodexCli.Protocol;
+using CodexCli.Models;
+using System.Collections.Generic;
+using Xunit;
+
+public class CodexInjectPendingInputTests
+{
+    [Fact]
+    public void InjectInput_WhenTaskRunningQueuesInput()
+    {
+        var state = new CodexState { HasCurrentTask = true };
+        var ok = Codex.InjectInput(state, new List<InputItem>{ new TextInputItem("hi") });
+        Assert.True(ok);
+        Assert.Single(state.PendingInput);
+        var item = Assert.IsType<MessageInputItem>(state.PendingInput[0]);
+        Assert.Equal("user", item.Role);
+        Assert.Equal("hi", item.Content[0].Text);
+    }
+
+    [Fact]
+    public void InjectInput_WhenNoTaskReturnsFalse()
+    {
+        var state = new CodexState { HasCurrentTask = false };
+        var ok = Codex.InjectInput(state, new List<InputItem>{ new TextInputItem("hi") });
+        Assert.False(ok);
+        Assert.Empty(state.PendingInput);
+    }
+
+    [Fact]
+    public void GetPendingInput_ReturnsAndClears()
+    {
+        var state = new CodexState { HasCurrentTask = true };
+        Codex.InjectInput(state, new List<InputItem>{ new TextInputItem("hi") });
+        var items = Codex.GetPendingInput(state);
+        Assert.Single(items);
+        Assert.Empty(state.PendingInput);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexMaybeNotifyTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexMaybeNotifyTests.cs
@@ -1,0 +1,27 @@
+using CodexCli.Util;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+public class CodexMaybeNotifyTests
+{
+    [Fact]
+    public async Task MaybeNotify_SpawnsCommand()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var cmd = new List<string>{"sh", "-c", $"echo hi > \"{tmp}\""};
+        Codex.MaybeNotify(cmd, new AgentTurnCompleteNotification("1", new string[0], "done"));
+        await Task.Delay(200);
+        Assert.True(File.Exists(tmp));
+        Assert.Equal("hi\n", await File.ReadAllTextAsync(tmp));
+    }
+
+    [Fact]
+    public void MaybeNotify_NoCommandDoesNothing()
+    {
+        Codex.MaybeNotify(null, new AgentTurnCompleteNotification("2", new string[0], "done"));
+        Codex.MaybeNotify(new List<string>(), new AgentTurnCompleteNotification("3", new string[0], "done"));
+    }
+}
+

--- a/codex-dotnet/CodexCli.Tests/CodexNotifyExecCommandTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexNotifyExecCommandTests.cs
@@ -1,0 +1,39 @@
+using CodexCli.Util;
+using CodexCli.Protocol;
+using CodexCli.Config;
+using CodexCli.Models;
+using Xunit;
+using System.Collections.Generic;
+
+public class CodexNotifyExecCommandTests
+{
+    [Fact]
+    public void BeginEvent_HasExpectedFields()
+    {
+        var policy = new ShellEnvironmentPolicy();
+        var p = new ExecParams(new List<string>{"echo","hi"}, "/tmp", null, ExecEnv.Create(policy));
+        var ev = Codex.NotifyExecCommandBegin("id1", "call1", p);
+        Assert.Equal("id1", ev.Id);
+        Assert.Equal(new[]{"echo","hi"}, ev.Command);
+        Assert.Equal("/tmp", ev.Cwd);
+    }
+
+    [Fact]
+    public void EndEvent_TruncatesOutput()
+    {
+        var stdout = new string('a', 6000);
+        var stderr = new string('b', 6000);
+        var ev = Codex.NotifyExecCommandEnd("id2", "call2", stdout, stderr, 0);
+        Assert.Equal(5120, ev.Stdout.Length);
+        Assert.Equal(5120, ev.Stderr.Length);
+        Assert.Equal(0, ev.ExitCode);
+    }
+
+    [Fact]
+    public void BackgroundEvent_HasMessage()
+    {
+        var ev = Codex.NotifyBackgroundEvent("id3", "hello");
+        Assert.Equal("id3", ev.Id);
+        Assert.Equal("hello", ev.Message);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexParseContainerExecArgumentsTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexParseContainerExecArgumentsTests.cs
@@ -1,0 +1,33 @@
+using CodexCli.Util;
+using CodexCli.Models;
+using CodexCli.Config;
+using System.IO;
+using Xunit;
+
+public class CodexParseContainerExecArgumentsTests
+{
+    [Fact]
+    public void ParsesArguments()
+    {
+        var json = "{\"command\":[\"echo\",\"hi\"],\"workdir\":\"sub\",\"timeout_ms\":5}";
+        var policy = new ShellEnvironmentPolicy();
+        bool ok = Codex.TryParseContainerExecArguments(json, policy, "/tmp", "123", out var execParams, out var err);
+        Assert.True(ok);
+        Assert.Null(err);
+        Assert.NotNull(execParams);
+        Assert.Equal(new[]{"echo","hi"}, execParams!.Command);
+        Assert.Equal(Path.GetFullPath(Path.Combine("/tmp","sub")), execParams.Cwd);
+        Assert.Equal(5, execParams.TimeoutMs);
+        Assert.NotEmpty(execParams.Env);
+    }
+
+    [Fact]
+    public void ReturnsErrorOnFailure()
+    {
+        var policy = new ShellEnvironmentPolicy();
+        bool ok = Codex.TryParseContainerExecArguments("not json", policy, "/tmp", "call", out var execParams, out var err);
+        Assert.False(ok);
+        Assert.Null(execParams);
+        Assert.NotNull(err);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexRecordConversationHistoryTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexRecordConversationHistoryTests.cs
@@ -1,0 +1,19 @@
+using CodexCli.Config;
+using CodexCli.Util;
+using Xunit;
+
+public class CodexRecordConversationHistoryTests
+{
+    [Fact]
+    public void DefaultsBasedOnWireApi()
+    {
+        Assert.False(Codex.RecordConversationHistory(false, WireApi.Responses));
+        Assert.True(Codex.RecordConversationHistory(false, WireApi.Chat));
+    }
+
+    [Fact]
+    public void DisableOverrides()
+    {
+        Assert.True(Codex.RecordConversationHistory(true, WireApi.Responses));
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexRecordConversationItemsTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexRecordConversationItemsTests.cs
@@ -1,0 +1,46 @@
+using CodexCli.Config;
+using CodexCli.Models;
+using CodexCli.Util;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+public class CodexRecordConversationItemsTests
+{
+    private static MessageItem Item() => new("assistant", new List<ContentItem>{ new("output_text", "hi") });
+
+    [Fact]
+    public async Task RecordsToTranscript()
+    {
+        var transcript = new ConversationHistory();
+        await Codex.RecordConversationItemsAsync(null, transcript, new[]{ Item() });
+        Assert.Single(transcript.Contents());
+    }
+
+    [Fact]
+    public async Task RecordsToRollout()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        var cfg = new AppConfig { CodexHome = dir };
+        await using var rec = await RolloutRecorder.CreateAsync(cfg, "sess", null);
+        await Codex.RecordConversationItemsAsync(rec, null, new[]{ Item() });
+        var lines = File.ReadAllLines(rec.FilePath);
+        Assert.True(lines.Length >= 2);
+    }
+
+    [Fact]
+    public async Task RecordsToBoth()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        var cfg = new AppConfig { CodexHome = dir };
+        await using var rec = await RolloutRecorder.CreateAsync(cfg, "sess", null);
+        var transcript = new ConversationHistory();
+        await Codex.RecordConversationItemsAsync(rec, transcript, new[]{ Item() });
+        var lines = File.ReadAllLines(rec.FilePath);
+        Assert.True(lines.Length >= 2);
+        Assert.Single(transcript.Contents());
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexRecordRolloutItemsTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexRecordRolloutItemsTests.cs
@@ -1,0 +1,29 @@
+using CodexCli.Config;
+using CodexCli.Models;
+using CodexCli.Util;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+public class CodexRecordRolloutItemsTests
+{
+    [Fact]
+    public async Task WritesToFile()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        var cfg = new AppConfig { CodexHome = dir };
+        await using var rec = await RolloutRecorder.CreateAsync(cfg, "sess", null);
+        var item = new MessageItem("assistant", new List<ContentItem>{ new("output_text", "hi") });
+        await Codex.RecordRolloutItemsAsync(rec, new[]{ item });
+        var lines = File.ReadAllLines(rec.FilePath);
+        Assert.True(lines.Length >= 2);
+    }
+
+    [Fact]
+    public async Task HandlesNullRecorder()
+    {
+        await Codex.RecordRolloutItemsAsync(null, new[] { new MessageItem("assistant", new List<ContentItem>{ new("output_text", "hi") }) });
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexResolvePathTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexResolvePathTests.cs
@@ -1,0 +1,29 @@
+using CodexCli.Util;
+using System.IO;
+using Xunit;
+
+public class CodexResolvePathTests
+{
+    [Fact]
+    public void ReturnsCwdWhenNull()
+    {
+        var cwd = "/home/user";
+        Assert.Equal(cwd, Codex.ResolvePath(cwd, null));
+    }
+
+    [Fact]
+    public void JoinsRelativePath()
+    {
+        var cwd = "/home/user";
+        var path = "sub/file.txt";
+        Assert.Equal(Path.Combine(cwd, path), Codex.ResolvePath(cwd, path));
+    }
+
+    [Fact]
+    public void ReturnsAbsolutePathUnchanged()
+    {
+        var cwd = "/home/user";
+        var abs = "/etc/passwd";
+        Assert.Equal(abs, Codex.ResolvePath(cwd, abs));
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexStatePartialCloneTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexStatePartialCloneTests.cs
@@ -1,0 +1,34 @@
+using CodexCli.Util;
+using CodexCli.Models;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+public class CodexStatePartialCloneTests
+{
+    [Fact]
+    public void ClonesApprovedCommandsAndPreviousResponseId()
+    {
+        var state = new CodexState();
+        state.ApprovedCommands.Add(new List<string>{"echo","hi"});
+        state.PreviousResponseId = "abc";
+        var clone = state.PartialClone(false);
+        Assert.Equal(state.PreviousResponseId, clone.PreviousResponseId);
+        Assert.Single(clone.ApprovedCommands);
+        Assert.NotSame(state.ApprovedCommands, clone.ApprovedCommands);
+        Assert.Equal(state.ApprovedCommands.First(), clone.ApprovedCommands.First());
+        Assert.Null(clone.ZdrTranscript);
+    }
+
+    [Fact]
+    public void OptionallyClonesTranscript()
+    {
+        var state = new CodexState();
+        var hist = new ConversationHistory();
+        hist.RecordItems(new[]{ new MessageItem("assistant", new List<ContentItem>{ new("output_text", "hi") }) });
+        state.ZdrTranscript = hist;
+        var clone = state.PartialClone(true);
+        Assert.NotNull(clone.ZdrTranscript);
+        Assert.Equal(hist.Contents().Count, clone.ZdrTranscript!.Contents().Count);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/CodexTaskManagementTests.cs
+++ b/codex-dotnet/CodexCli.Tests/CodexTaskManagementTests.cs
@@ -1,0 +1,45 @@
+using CodexCli.Util;
+using Xunit;
+
+public class CodexTaskManagementTests
+{
+    [Fact]
+    public void SetTask_ReplacesExistingTaskAndAbortsOld()
+    {
+        var state = new CodexState();
+        bool aborted1 = false;
+        var t1 = new AgentTask("1", () => aborted1 = true);
+        Codex.SetTask(state, t1);
+        Assert.True(state.HasCurrentTask);
+        Assert.Equal(t1, state.CurrentTask);
+
+        bool aborted2 = false;
+        var t2 = new AgentTask("2", () => aborted2 = true);
+        Codex.SetTask(state, t2);
+        Assert.True(aborted1);
+        Assert.False(aborted2);
+        Assert.Equal(t2, state.CurrentTask);
+    }
+
+    [Fact]
+    public void RemoveTask_MatchingSubIdClearsTask()
+    {
+        var state = new CodexState();
+        var t1 = new AgentTask("abc", () => { });
+        Codex.SetTask(state, t1);
+        Codex.RemoveTask(state, "abc");
+        Assert.False(state.HasCurrentTask);
+        Assert.Null(state.CurrentTask);
+    }
+
+    [Fact]
+    public void RemoveTask_IgnoresDifferentSubId()
+    {
+        var state = new CodexState();
+        var t1 = new AgentTask("abc", () => { });
+        Codex.SetTask(state, t1);
+        Codex.RemoveTask(state, "xyz");
+        Assert.True(state.HasCurrentTask);
+        Assert.Equal(t1, state.CurrentTask);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/PatchApplierApplyActionTests.cs
+++ b/codex-dotnet/CodexCli.Tests/PatchApplierApplyActionTests.cs
@@ -1,0 +1,31 @@
+using CodexCli.ApplyPatch;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+public class PatchApplierApplyActionTests
+{
+    [Fact]
+    public void ApplyActionWritesSummary()
+    {
+        using var dir = new TempDir();
+        var path = Path.Combine(dir.Path, "a.txt");
+        var action = new ApplyPatchAction(new Dictionary<string, ApplyPatchFileChange>
+        {
+            [path] = new ApplyPatchFileChange { Kind = "add", Content = "hi" }
+        });
+        var sw = new StringWriter();
+        PatchApplier.ApplyActionAndReport(action, sw, TextWriter.Null);
+        Assert.True(File.Exists(path));
+        var output = sw.ToString();
+        Assert.Contains("Success. Updated the following files:", output);
+        Assert.Contains($"A {path}", output);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+        public TempDir() { Directory.CreateDirectory(Path); }
+        public void Dispose() { Directory.Delete(Path, true); }
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/PatchApplierApplyAndReportTests.cs
+++ b/codex-dotnet/CodexCli.Tests/PatchApplierApplyAndReportTests.cs
@@ -1,0 +1,25 @@
+using CodexCli.ApplyPatch;
+using Xunit;
+using System.IO;
+
+public class PatchApplierApplyAndReportTests
+{
+    [Fact]
+    public void ApplyAndReportOutputsSummary()
+    {
+        using var dir = new TempDir();
+        var patch = "*** Begin Patch\n*** Add File: foo.txt\n+hi\n*** End Patch";
+        var sw = new StringWriter();
+        PatchApplier.ApplyAndReport(patch, dir.Path, sw, TextWriter.Null);
+        var output = sw.ToString();
+        Assert.True(File.Exists(Path.Combine(dir.Path, "foo.txt")));
+        Assert.Contains("A foo.txt", output);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+        public TempDir() { Directory.CreateDirectory(Path); }
+        public void Dispose() { Directory.Delete(Path, true); }
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/PatchApplierSummaryIntegrationTests.cs
+++ b/codex-dotnet/CodexCli.Tests/PatchApplierSummaryIntegrationTests.cs
@@ -1,0 +1,26 @@
+using CodexCli.ApplyPatch;
+using Xunit;
+using System.IO;
+
+public class PatchApplierSummaryIntegrationTests
+{
+    [Fact]
+    public void ApplyAndPrintSummary()
+    {
+        using var dir = new TempDir();
+        var patch = "*** Begin Patch\n*** Add File: foo.txt\n+hi\n*** End Patch";
+        var result = PatchApplier.ApplyWithSummary(patch, dir.Path);
+        using var sw = new StringWriter();
+        PatchSummary.PrintSummary(result.Affected, sw);
+        var summary = sw.ToString();
+        Assert.Contains("A foo.txt", summary);
+        Assert.True(File.Exists(Path.Combine(dir.Path, "foo.txt")));
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+        public TempDir() { Directory.CreateDirectory(Path); }
+        public void Dispose() { Directory.Delete(Path, true); }
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/PatchSummaryTests.cs
+++ b/codex-dotnet/CodexCli.Tests/PatchSummaryTests.cs
@@ -1,0 +1,23 @@
+using CodexCli.ApplyPatch;
+using Xunit;
+using System.IO;
+using System.Collections.Generic;
+
+public class PatchSummaryTests
+{
+    [Fact]
+    public void WritesSummary()
+    {
+        var affected = new AffectedPaths(
+            new List<string>{"a.txt"},
+            new List<string>{"b.txt"},
+            new List<string>{"c.txt"});
+        var sw = new StringWriter();
+        PatchSummary.PrintSummary(affected, sw);
+        var text = sw.ToString();
+        Assert.Contains("Success. Updated the following files:", text);
+        Assert.Contains("A a.txt", text);
+        Assert.Contains("M b.txt", text);
+        Assert.Contains("D c.txt", text);
+    }
+}

--- a/codex-dotnet/CodexCli.Tests/PromptTests.cs
+++ b/codex-dotnet/CodexCli.Tests/PromptTests.cs
@@ -9,7 +9,7 @@ public class PromptTests
         var prompt = new Prompt { UserInstructions = "Be helpful" };
         var res = prompt.GetFullInstructions("gpt-4.1");
         Assert.Contains("Be helpful", res);
-        Assert.Contains("ApplyPatch", res);
+        Assert.Contains("apply_patch", res);
     }
 
     [Fact]
@@ -17,7 +17,8 @@ public class PromptTests
     {
         var prompt = new Prompt();
         var res = prompt.GetFullInstructions("codex");
-        Assert.StartsWith("You are Codex", res);
-        Assert.DoesNotContain("ApplyPatch", res);
+        Assert.StartsWith("Please resolve", res);
+        Assert.DoesNotContain("apply_patch", res);
+        Assert.Contains("deployed coding agent", res);
     }
 }

--- a/codex-dotnet/CodexCli.Tests/SafetyPlatformSandboxTests.cs
+++ b/codex-dotnet/CodexCli.Tests/SafetyPlatformSandboxTests.cs
@@ -1,0 +1,24 @@
+using CodexCli.Util;
+using CodexCli.Protocol;
+using Xunit;
+
+public class SafetyPlatformSandboxTests
+{
+    [Fact]
+    public void GetPlatformSandbox_ReturnsExpectedValue()
+    {
+        var sandbox = Safety.GetPlatformSandbox();
+#if NET7_0_OR_GREATER
+        if (OperatingSystem.IsLinux())
+            Assert.Equal(SandboxType.LinuxSeccomp, sandbox);
+        else if (OperatingSystem.IsMacOS())
+            Assert.Equal(SandboxType.MacosSeatbelt, sandbox);
+        else
+            Assert.Null(sandbox);
+#else
+        // Simplified assumption for test environments
+        Assert.NotNull(sandbox);
+#endif
+    }
+}
+

--- a/codex-dotnet/CodexCli.Tests/SafetyWritableRootsConstraintTests.cs
+++ b/codex-dotnet/CodexCli.Tests/SafetyWritableRootsConstraintTests.cs
@@ -1,0 +1,27 @@
+using CodexCli.ApplyPatch;
+using CodexCli.Util;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+public class SafetyWritableRootsConstraintTests
+{
+    [Fact]
+    public void WritableRootsConstraint()
+    {
+        var cwd = Directory.GetCurrentDirectory();
+        var parent = Directory.GetParent(cwd)!.FullName;
+        ApplyPatchAction MakeAdd(string p) => new(new Dictionary<string, ApplyPatchFileChange>
+        {
+            [p] = new ApplyPatchFileChange { Kind = "add", Content = "" }
+        });
+
+        var addInside = MakeAdd(Path.Combine(cwd, "inner.txt"));
+        var addOutside = MakeAdd(Path.Combine(parent, "outside.txt"));
+        var addOutside2 = MakeAdd(Path.Combine(parent, "outside.txt"));
+
+        Assert.True(Safety.IsWritePatchConstrainedToWritableRoots(addInside, new List<string>{"."}, cwd));
+        Assert.False(Safety.IsWritePatchConstrainedToWritableRoots(addOutside2, new List<string>{"."}, cwd));
+        Assert.True(Safety.IsWritePatchConstrainedToWritableRoots(addOutside, new List<string>{".."}, cwd));
+    }
+}

--- a/codex-dotnet/CodexCli/ApplyPatch/ApplyPatchCommandParser.cs
+++ b/codex-dotnet/CodexCli/ApplyPatch/ApplyPatchCommandParser.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
+// Ported from codex-rs/apply-patch/src/lib.rs maybe_parse_apply_patch functions and heredoc parser (done).
+
 namespace CodexCli.ApplyPatch;
 
 public enum MaybeApplyPatch

--- a/codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs
+++ b/codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs
@@ -1,4 +1,10 @@
 using System.Text;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+
+// Ports of apply_changes_from_apply_patch and apply_changes_from_apply_patch_and_report
+// from codex-rs/core/src/codex.rs.
 
 namespace CodexCli.ApplyPatch;
 
@@ -73,6 +79,71 @@ public static class PatchApplier
 
         var summary = stdout.ToString();
         return (new AffectedPaths(added, modified, deleted), summary);
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `apply_changes_from_apply_patch` (done).
+    /// Applies an already-parsed patch action.
+    /// </summary>
+    public static AffectedPaths ApplyAction(ApplyPatchAction action)
+    {
+        var added = new List<string>();
+        var modified = new List<string>();
+        var deleted = new List<string>();
+        foreach (var kv in action.Changes)
+        {
+            var path = kv.Key;
+            var change = kv.Value;
+            switch (change.Kind)
+            {
+                case "add":
+                    Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                    File.WriteAllText(path, change.Content ?? string.Empty);
+                    added.Add(path);
+                    break;
+                case "delete":
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                        deleted.Add(path);
+                    }
+                    break;
+                case "update":
+                    var lines = File.Exists(path) ? File.ReadAllLines(path).ToList() : new List<string>();
+                    var diffLines = PatchParser.ParseUnified(change.UnifiedDiff ?? string.Empty);
+                    lines = ApplyUnifiedDiff(lines, diffLines);
+                    var outPath = path;
+                    if (change.MovePath != null)
+                    {
+                        Directory.CreateDirectory(Path.GetDirectoryName(change.MovePath)!);
+                        File.Move(path, change.MovePath, true);
+                        outPath = change.MovePath;
+                        deleted.Add(path);
+                    }
+                    File.WriteAllLines(outPath, lines);
+                    modified.Add(outPath);
+                    break;
+            }
+        }
+
+        return new AffectedPaths(added, modified, deleted);
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `apply_changes_from_apply_patch_and_report` (done).
+    /// Writes a summary or error to the provided writers.
+    /// </summary>
+    public static void ApplyActionAndReport(ApplyPatchAction action, TextWriter stdout, TextWriter stderr)
+    {
+        try
+        {
+            var affected = ApplyAction(action);
+            PatchSummary.PrintSummary(affected, stdout);
+        }
+        catch (Exception e)
+        {
+            stderr.WriteLine(e.Message);
+        }
     }
 
     private static List<string> ApplyUnifiedDiff(List<string> original, List<string> diffLines)

--- a/codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs
+++ b/codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 // Ports of apply_changes_from_apply_patch and apply_changes_from_apply_patch_and_report
-// from codex-rs/core/src/codex.rs.
+// from codex-rs/core/src/codex.rs. Also ports apply_patch from codex-rs/apply-patch/src/lib.rs.
 
 namespace CodexCli.ApplyPatch;
 
@@ -141,6 +141,23 @@ public static class PatchApplier
             PatchSummary.PrintSummary(affected, stdout);
         }
         catch (Exception e)
+        {
+            stderr.WriteLine(e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/apply-patch/src/lib.rs `apply_patch` (done).
+    /// Parses a patch string and prints the result to the provided writers.
+    /// </summary>
+    public static void ApplyAndReport(string patch, string cwd, TextWriter stdout, TextWriter stderr)
+    {
+        try
+        {
+            var result = ApplyWithSummary(patch, cwd);
+            PatchSummary.PrintSummary(result.Affected, stdout);
+        }
+        catch (PatchParseException e)
         {
             stderr.WriteLine(e.Message);
         }

--- a/codex-dotnet/CodexCli/ApplyPatch/PatchSummary.cs
+++ b/codex-dotnet/CodexCli/ApplyPatch/PatchSummary.cs
@@ -1,0 +1,20 @@
+using System.IO;
+
+namespace CodexCli.ApplyPatch;
+
+/// <summary>
+/// Ported from codex-rs/apply-patch/src/lib.rs `print_summary` (done).
+/// </summary>
+public static class PatchSummary
+{
+    public static void PrintSummary(AffectedPaths affected, TextWriter output)
+    {
+        output.WriteLine("Success. Updated the following files:");
+        foreach (var path in affected.Added)
+            output.WriteLine($"A {path}");
+        foreach (var path in affected.Modified)
+            output.WriteLine($"M {path}");
+        foreach (var path in affected.Deleted)
+            output.WriteLine($"D {path}");
+    }
+}

--- a/codex-dotnet/CodexCli/ApplyPatch/apply_patch_tool_instructions.md
+++ b/codex-dotnet/CodexCli/ApplyPatch/apply_patch_tool_instructions.md
@@ -1,3 +1,4 @@
+<!-- Source: codex-rs/apply-patch/apply_patch_tool_instructions.md -->
 To edit files, ALWAYS use the `shell` tool with `apply_patch` CLI.  `apply_patch` effectively allows you to execute a diff/patch against a file, but the format of the diff specification is unique to this task, so pay careful attention to these instructions. To use the `apply_patch` CLI, you should call the shell tool with the following structure:
 
 ```bash

--- a/codex-dotnet/CodexCli/CodexCli.csproj
+++ b/codex-dotnet/CodexCli/CodexCli.csproj
@@ -14,5 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Login/login_with_chatgpt.py" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="prompt.md" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="ApplyPatch/apply_patch_tool_instructions.md" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/codex-dotnet/CodexCli/Commands/ApplyPatchCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/ApplyPatchCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using CodexCli.ApplyPatch;
+using System.IO;
 
 namespace CodexCli.Commands;
 
@@ -25,10 +26,10 @@ public static class ApplyPatchCommand
             try
             {
                 var result = PatchApplier.ApplyWithSummary(patchText, cwd);
-                if (summaryOnly)
-                    Console.WriteLine(result.Summary);
-                else
-                    Console.WriteLine(result.Summary);
+                using var sw = new StringWriter();
+                PatchSummary.PrintSummary(result.Affected, sw);
+                var summaryText = sw.ToString();
+                Console.WriteLine(summaryText);
             }
             catch (PatchParseException e)
             {

--- a/codex-dotnet/CodexCli/Commands/ApplyPatchCommand.cs
+++ b/codex-dotnet/CodexCli/Commands/ApplyPatchCommand.cs
@@ -25,11 +25,7 @@ public static class ApplyPatchCommand
             cwd ??= Directory.GetCurrentDirectory();
             try
             {
-                var result = PatchApplier.ApplyWithSummary(patchText, cwd);
-                using var sw = new StringWriter();
-                PatchSummary.PrintSummary(result.Affected, sw);
-                var summaryText = sw.ToString();
-                Console.WriteLine(summaryText);
+                PatchApplier.ApplyAndReport(patchText, cwd, Console.Out, Console.Error);
             }
             catch (PatchParseException e)
             {

--- a/codex-dotnet/CodexCli/Models/Prompt.cs
+++ b/codex-dotnet/CodexCli/Models/Prompt.cs
@@ -34,6 +34,13 @@ public class Prompt
     private static string LoadInstructions(string relative)
     {
         var path = Path.Combine(AppContext.BaseDirectory, relative);
-        return File.Exists(path) ? File.ReadAllText(path) : "";
+        if (!File.Exists(path))
+            return string.Empty;
+
+        var lines = File.ReadAllLines(path);
+        int start = 0;
+        while (start < lines.Length && lines[start].TrimStart().StartsWith("<!--"))
+            start++;
+        return string.Join('\n', lines[start..]);
     }
 }

--- a/codex-dotnet/CodexCli/Models/Prompt.cs
+++ b/codex-dotnet/CodexCli/Models/Prompt.cs
@@ -5,6 +5,8 @@ namespace CodexCli.Models;
 
 using System.Collections.Generic;
 using System.Text;
+using System.IO;
+using System;
 using CodexCli.Util;
 
 public class Prompt
@@ -15,7 +17,7 @@ public class Prompt
     public bool Store { get; set; }
     public Dictionary<string, Tool> ExtraTools { get; } = new();
 
-    private const string BaseInstructions = "You are Codex, a coding assistant."; // from prompt.md
+    private static readonly string BaseInstructions = LoadInstructions("prompt.md");
 
     public string GetFullInstructions(string model)
     {
@@ -27,5 +29,11 @@ public class Prompt
         return string.Join('\n', sections);
     }
 
-    private const string ApplyPatchToolInstructions = "ApplyPatch tool usage";
+    private static readonly string ApplyPatchToolInstructions = LoadInstructions(Path.Combine("ApplyPatch", "apply_patch_tool_instructions.md"));
+
+    private static string LoadInstructions(string relative)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, relative);
+        return File.Exists(path) ? File.ReadAllText(path) : "";
+    }
 }

--- a/codex-dotnet/CodexCli/Protocol/InputItem.cs
+++ b/codex-dotnet/CodexCli/Protocol/InputItem.cs
@@ -1,0 +1,51 @@
+// Rust analog: codex-rs/core/src/protocol.rs InputItem (done)
+namespace CodexCli.Protocol;
+
+using System;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.IO;
+using CodexCli.Models;
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(TextInputItem), typeDiscriminator: "text")]
+[JsonDerivedType(typeof(ImageInputItem), typeDiscriminator: "image")]
+[JsonDerivedType(typeof(LocalImageInputItem), typeDiscriminator: "local_image")]
+public abstract record InputItem
+{
+    public static ResponseInputItem ToResponse(IEnumerable<InputItem> items)
+    {
+        var content = new List<ContentItem>();
+        foreach (var item in items)
+        {
+            switch (item)
+            {
+                case TextInputItem t:
+                    content.Add(new ContentItem("input_text", t.Text));
+                    break;
+                case ImageInputItem i:
+                    content.Add(new ContentItem("input_image", i.ImageUrl));
+                    break;
+                case LocalImageInputItem li:
+                    try
+                    {
+                        var bytes = File.ReadAllBytes(li.Path);
+                        var mime = MimeTypes.GetMimeType(li.Path);
+                        var encoded = Convert.ToBase64String(bytes);
+                        var dataUrl = $"data:{mime};base64,{encoded}";
+                        content.Add(new ContentItem("input_image", dataUrl));
+                    }
+                    catch (Exception e)
+                    {
+                        Console.Error.WriteLine($"Skipping image {li.Path}: {e.Message}");
+                    }
+                    break;
+            }
+        }
+        return new MessageInputItem("user", content);
+    }
+}
+
+public record TextInputItem(string Text) : InputItem;
+public record ImageInputItem(string ImageUrl) : InputItem;
+public record LocalImageInputItem(string Path) : InputItem;

--- a/codex-dotnet/CodexCli/Protocol/MimeTypes.cs
+++ b/codex-dotnet/CodexCli/Protocol/MimeTypes.cs
@@ -1,0 +1,19 @@
+using System.IO;
+
+namespace CodexCli.Protocol;
+
+// Minimal mime type helper for InputItem.ToResponse
+internal static class MimeTypes
+{
+    public static string GetMimeType(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext switch
+        {
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            _ => "application/octet-stream",
+        };
+    }
+}

--- a/codex-dotnet/CodexCli/Protocol/SandboxType.cs
+++ b/codex-dotnet/CodexCli/Protocol/SandboxType.cs
@@ -1,0 +1,14 @@
+namespace CodexCli.Protocol;
+
+/// <summary>
+/// Ported from codex-rs/core/src/exec.rs `SandboxType` (done).
+/// </summary>
+public enum SandboxType
+{
+    None,
+    /// <summary>Only available on macOS.</summary>
+    MacosSeatbelt,
+    /// <summary>Only available on Linux.</summary>
+    LinuxSeccomp,
+}
+

--- a/codex-dotnet/CodexCli/Util/AgentTask.cs
+++ b/codex-dotnet/CodexCli/Util/AgentTask.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace CodexCli.Util;
+
+/// <summary>
+/// Simple representation of a running agent task used by Codex.SetTask.
+/// Ported from codex-rs/core/src/codex.rs `AgentTask` (partial).
+/// </summary>
+public class AgentTask
+{
+    public string SubId { get; }
+    private readonly Action _abort;
+    public bool Aborted { get; private set; }
+
+    public AgentTask(string subId, Action abort)
+    {
+        SubId = subId;
+        _abort = abort;
+    }
+
+    public void Abort()
+    {
+        Aborted = true;
+        _abort?.Invoke();
+    }
+}

--- a/codex-dotnet/CodexCli/Util/Codex.cs
+++ b/codex-dotnet/CodexCli/Util/Codex.cs
@@ -1,6 +1,8 @@
 // Rust analog: codex-rs/core/src/codex.rs (partial)
 // Ported from codex-rs/core/src/codex.rs spawn interface (partial)
 using CodexCli.Protocol;
+using CodexCli.Models;
+using CodexCli.Config;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -71,5 +73,35 @@ public class Codex
         }
         roots.Add(cwd);
         return roots;
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `get_last_assistant_message_from_turn` (done).
+    /// </summary>
+    public static string? GetLastAssistantMessageFromTurn(List<ResponseItem> responses)
+    {
+        for (int i = responses.Count - 1; i >= 0; i--)
+        {
+            if (responses[i] is MessageItem mi && mi.Role == "assistant")
+            {
+                for (int j = mi.Content.Count - 1; j >= 0; j--)
+                {
+                    var ci = mi.Content[j];
+                    if (ci.Type == "output_text")
+                        return ci.Text;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `record_conversation_history` (done).
+    /// </summary>
+    public static bool RecordConversationHistory(bool disableResponseStorage, WireApi wireApi)
+    {
+        if (disableResponseStorage)
+            return true;
+        return wireApi == WireApi.Chat;
     }
 }

--- a/codex-dotnet/CodexCli/Util/Codex.cs
+++ b/codex-dotnet/CodexCli/Util/Codex.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Text.Json;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace CodexCli.Util;
 
@@ -326,5 +327,34 @@ public class Codex
             state.CurrentTask = null;
             state.HasCurrentTask = false;
         }
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `record_rollout_items` (done).
+    /// Appends the items to the rollout recorder if it is not null.
+    /// </summary>
+    public static async Task RecordRolloutItemsAsync(RolloutRecorder? recorder, IEnumerable<ResponseItem> items)
+    {
+        if (recorder == null)
+            return;
+
+        try
+        {
+            await recorder.RecordItemsAsync(items);
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"failed to record rollout items: {e.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `record_conversation_items` (done).
+    /// Records items to the rollout and conversation transcript if provided.
+    /// </summary>
+    public static async Task RecordConversationItemsAsync(RolloutRecorder? recorder, ConversationHistory? transcript, IEnumerable<ResponseItem> items)
+    {
+        await RecordRolloutItemsAsync(recorder, items);
+        transcript?.RecordItems(items);
     }
 }

--- a/codex-dotnet/CodexCli/Util/Codex.cs
+++ b/codex-dotnet/CodexCli/Util/Codex.cs
@@ -238,6 +238,32 @@ public class Codex
     }
 
     /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `inject_input` (done).
+    /// Adds user input to the pending queue if a task is running.
+    /// Returns true if the input was queued, otherwise false.
+    /// </summary>
+    public static bool InjectInput(CodexState state, List<InputItem> input)
+    {
+        if (state.HasCurrentTask)
+        {
+            state.PendingInput.Add(InputItem.ToResponse(input));
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `get_pending_input` (done).
+    /// Returns any queued input and clears the pending list.
+    /// </summary>
+    public static List<ResponseInputItem> GetPendingInput(CodexState state)
+    {
+        var ret = new List<ResponseInputItem>(state.PendingInput);
+        state.PendingInput.Clear();
+        return ret;
+    }
+
+    /// <summary>
     /// Ported from codex-rs/core/src/codex.rs `notify_exec_command_begin` (done).
     /// Creates an ExecCommandBeginEvent for the given parameters.
     /// </summary>

--- a/codex-dotnet/CodexCli/Util/Codex.cs
+++ b/codex-dotnet/CodexCli/Util/Codex.cs
@@ -1,7 +1,9 @@
 // Rust analog: codex-rs/core/src/codex.rs (partial)
 // Ported from codex-rs/core/src/codex.rs spawn interface (partial)
 using CodexCli.Protocol;
+using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading;
 
 namespace CodexCli.Util;
@@ -35,4 +37,21 @@ public class Codex
     }
 
     public void Cancel() => _ctrlC.Cancel();
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `format_exec_output` (done).
+    /// </summary>
+    public static string FormatExecOutput(string output, int exitCode, TimeSpan duration)
+    {
+        var payload = new
+        {
+            output,
+            metadata = new
+            {
+                exit_code = exitCode,
+                duration_seconds = Math.Round(duration.TotalSeconds * 10) / 10
+            }
+        };
+        return JsonSerializer.Serialize(payload);
+    }
 }

--- a/codex-dotnet/CodexCli/Util/Codex.cs
+++ b/codex-dotnet/CodexCli/Util/Codex.cs
@@ -236,4 +236,34 @@ public class Codex
             Console.Error.WriteLine($"failed to spawn notifier '{notifyCommand[0]}': {e.Message}");
         }
     }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `notify_exec_command_begin` (done).
+    /// Creates an ExecCommandBeginEvent for the given parameters.
+    /// </summary>
+    public static ExecCommandBeginEvent NotifyExecCommandBegin(string subId, string callId, ExecParams parameters)
+    {
+        return new ExecCommandBeginEvent(subId, parameters.Command, parameters.Cwd);
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `notify_exec_command_end` (done).
+    /// Creates an ExecCommandEndEvent with truncated output streams.
+    /// </summary>
+    public static ExecCommandEndEvent NotifyExecCommandEnd(string subId, string callId, string stdout, string stderr, int exitCode)
+    {
+        const int MaxStreamOutput = 5 * 1024;
+        var outTrunc = stdout.Length > MaxStreamOutput ? stdout[..MaxStreamOutput] : stdout;
+        var errTrunc = stderr.Length > MaxStreamOutput ? stderr[..MaxStreamOutput] : stderr;
+        return new ExecCommandEndEvent(subId, outTrunc, errTrunc, exitCode);
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `notify_background_event` (done).
+    /// Creates a BackgroundEvent with the provided message.
+    /// </summary>
+    public static BackgroundEvent NotifyBackgroundEvent(string subId, string message)
+    {
+        return new BackgroundEvent(subId, message);
+    }
 }

--- a/codex-dotnet/CodexCli/Util/Codex.cs
+++ b/codex-dotnet/CodexCli/Util/Codex.cs
@@ -303,4 +303,28 @@ public class Codex
     {
         return new BackgroundEvent(subId, message);
     }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `set_task` (done).
+    /// Replaces any current task with the provided one, aborting the old task.
+    /// </summary>
+    public static void SetTask(CodexState state, AgentTask task)
+    {
+        state.CurrentTask?.Abort();
+        state.CurrentTask = task;
+        state.HasCurrentTask = true;
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `remove_task` (done).
+    /// Removes the task if its subId matches.
+    /// </summary>
+    public static void RemoveTask(CodexState state, string subId)
+    {
+        if (state.CurrentTask != null && state.CurrentTask.SubId == subId)
+        {
+            state.CurrentTask = null;
+            state.HasCurrentTask = false;
+        }
+    }
 }

--- a/codex-dotnet/CodexCli/Util/Codex.cs
+++ b/codex-dotnet/CodexCli/Util/Codex.cs
@@ -3,6 +3,7 @@
 using CodexCli.Protocol;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Json;
 using System.Threading;
 
@@ -53,5 +54,22 @@ public class Codex
             }
         };
         return JsonSerializer.Serialize(payload);
+    }
+
+    /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `get_writable_roots` (done).
+    /// </summary>
+    public static List<string> GetWritableRoots(string cwd)
+    {
+        var roots = new List<string>();
+        if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+        {
+            roots.Add(Path.GetTempPath());
+            var home = Environment.GetEnvironmentVariable("HOME");
+            if (!string.IsNullOrEmpty(home))
+                roots.Add(Path.Combine(home, ".pyenv"));
+        }
+        roots.Add(cwd);
+        return roots;
     }
 }

--- a/codex-dotnet/CodexCli/Util/Codex.cs
+++ b/codex-dotnet/CodexCli/Util/Codex.cs
@@ -78,6 +78,17 @@ public class Codex
     }
 
     /// <summary>
+    /// Ported from codex-rs/core/src/codex.rs `resolve_path` (done).
+    /// Joins <paramref name="path"/> to <paramref name="cwd"/> if provided, otherwise returns <paramref name="cwd"/>.
+    /// </summary>
+    public static string ResolvePath(string cwd, string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return cwd;
+        return Path.IsPathRooted(path) ? path : Path.Combine(cwd, path);
+    }
+
+    /// <summary>
     /// Ported from codex-rs/core/src/codex.rs `get_last_assistant_message_from_turn` (done).
     /// </summary>
     public static string? GetLastAssistantMessageFromTurn(List<ResponseItem> responses)

--- a/codex-dotnet/CodexCli/Util/CodexState.cs
+++ b/codex-dotnet/CodexCli/Util/CodexState.cs
@@ -1,3 +1,5 @@
+using CodexCli.Models;
+
 namespace CodexCli.Util;
 
 /// <summary>
@@ -9,6 +11,8 @@ public class CodexState
     public HashSet<List<string>> ApprovedCommands { get; } = new();
     public string? PreviousResponseId { get; set; }
     public ConversationHistory? ZdrTranscript { get; set; }
+    public bool HasCurrentTask { get; set; }
+    public List<ResponseInputItem> PendingInput { get; } = new();
 
     public CodexState PartialClone(bool retainZdrTranscript)
     {
@@ -19,6 +23,7 @@ public class CodexState
         };
         foreach (var cmd in ApprovedCommands)
             clone.ApprovedCommands.Add(new List<string>(cmd));
+        clone.HasCurrentTask = this.HasCurrentTask;
         return clone;
     }
 }

--- a/codex-dotnet/CodexCli/Util/CodexState.cs
+++ b/codex-dotnet/CodexCli/Util/CodexState.cs
@@ -1,4 +1,6 @@
 using CodexCli.Models;
+using CodexCli.Protocol;
+using System.Threading.Tasks;
 
 namespace CodexCli.Util;
 
@@ -14,6 +16,7 @@ public class CodexState
     public bool HasCurrentTask { get; set; }
     public AgentTask? CurrentTask { get; set; }
     public List<ResponseInputItem> PendingInput { get; } = new();
+    public Dictionary<string, TaskCompletionSource<ReviewDecision>> PendingApprovals { get; } = new();
 
     public CodexState PartialClone(bool retainZdrTranscript)
     {

--- a/codex-dotnet/CodexCli/Util/CodexState.cs
+++ b/codex-dotnet/CodexCli/Util/CodexState.cs
@@ -1,0 +1,24 @@
+namespace CodexCli.Util;
+
+/// <summary>
+/// Ported from codex-rs/core/src/codex.rs `State.partial_clone` (done).
+/// Represents mutable state for a Codex session.
+/// </summary>
+public class CodexState
+{
+    public HashSet<List<string>> ApprovedCommands { get; } = new();
+    public string? PreviousResponseId { get; set; }
+    public ConversationHistory? ZdrTranscript { get; set; }
+
+    public CodexState PartialClone(bool retainZdrTranscript)
+    {
+        var clone = new CodexState
+        {
+            PreviousResponseId = this.PreviousResponseId,
+            ZdrTranscript = retainZdrTranscript ? this.ZdrTranscript?.Clone() : null
+        };
+        foreach (var cmd in ApprovedCommands)
+            clone.ApprovedCommands.Add(new List<string>(cmd));
+        return clone;
+    }
+}

--- a/codex-dotnet/CodexCli/Util/CodexState.cs
+++ b/codex-dotnet/CodexCli/Util/CodexState.cs
@@ -12,6 +12,7 @@ public class CodexState
     public string? PreviousResponseId { get; set; }
     public ConversationHistory? ZdrTranscript { get; set; }
     public bool HasCurrentTask { get; set; }
+    public AgentTask? CurrentTask { get; set; }
     public List<ResponseInputItem> PendingInput { get; } = new();
 
     public CodexState PartialClone(bool retainZdrTranscript)
@@ -24,6 +25,7 @@ public class CodexState
         foreach (var cmd in ApprovedCommands)
             clone.ApprovedCommands.Add(new List<string>(cmd));
         clone.HasCurrentTask = this.HasCurrentTask;
+        // current task is intentionally not cloned
         return clone;
     }
 }

--- a/codex-dotnet/CodexCli/Util/ConversationHistory.cs
+++ b/codex-dotnet/CodexCli/Util/ConversationHistory.cs
@@ -24,4 +24,11 @@ public class ConversationHistory
         LocalShellCallItem => true,
         _ => false
     };
+
+    public ConversationHistory Clone()
+    {
+        var clone = new ConversationHistory();
+        clone._items.AddRange(_items);
+        return clone;
+    }
 }

--- a/codex-dotnet/CodexCli/Util/Safety.cs
+++ b/codex-dotnet/CodexCli/Util/Safety.cs
@@ -37,7 +37,7 @@ public static class Safety
         };
     }
 
-    internal static bool IsWritePatchConstrainedToWritableRoots(ApplyPatchAction action, List<string> writableRoots, string cwd)
+    public static bool IsWritePatchConstrainedToWritableRoots(ApplyPatchAction action, List<string> writableRoots, string cwd)
     {
         if (writableRoots.Count == 0)
             return false;

--- a/codex-dotnet/CodexCli/Util/Safety.cs
+++ b/codex-dotnet/CodexCli/Util/Safety.cs
@@ -89,6 +89,18 @@ public static class Safety
         return SafetyCheck.AskUser;
     }
 
+    /// <summary>
+    /// Ported from codex-rs/core/src/safety.rs `get_platform_sandbox` (done).
+    /// Returns the default sandbox type for the current platform if supported.
+    /// </summary>
+    public static SandboxType? GetPlatformSandbox()
+    {
+        if (OperatingSystem.IsMacOS()) return SandboxType.MacosSeatbelt;
+        if (OperatingSystem.IsLinux()) return SandboxType.LinuxSeccomp;
+        return null;
+    }
+
     // Helpers for earlier versions retained for completeness, though not used
     // in current ports.
 }
+

--- a/codex-dotnet/CodexCli/Util/Safety.cs
+++ b/codex-dotnet/CodexCli/Util/Safety.cs
@@ -1,8 +1,11 @@
-// Port of codex-rs/core/src/safety.rs (simplified, done)
+// Port of codex-rs/core/src/safety.rs assess_patch_safety and helpers (done)
 using CodexCli.ApplyPatch;
 using CodexCli.Protocol;
 using CodexCli.Models;
 using CodexCli.Commands;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
 
 namespace CodexCli.Util;
 
@@ -23,9 +26,7 @@ public static class Safety
         if (policy == ApprovalMode.UnlessAllowListed)
             return SafetyCheck.AskUser;
 
-        bool allWritable = action.Changes.Keys.All(p => IsPathWritable(Path.Combine(cwd, p), writableRoots));
-
-        if (allWritable)
+        if (IsWritePatchConstrainedToWritableRoots(action, writableRoots, cwd))
             return SafetyCheck.AutoApprove;
 
         return policy switch
@@ -34,6 +35,44 @@ public static class Safety
             ApprovalMode.Never => SafetyCheck.Reject,
             _ => SafetyCheck.AskUser
         };
+    }
+
+    internal static bool IsWritePatchConstrainedToWritableRoots(ApplyPatchAction action, List<string> writableRoots, string cwd)
+    {
+        if (writableRoots.Count == 0)
+            return false;
+
+        bool IsWritable(string path)
+        {
+            var abs = Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(cwd, path));
+            return writableRoots.Any(root =>
+            {
+                var rootAbs = Path.GetFullPath(Path.IsPathRooted(root) ? root : Path.Combine(cwd, root));
+                return abs.StartsWith(rootAbs);
+            });
+        }
+
+        foreach (var kv in action.Changes)
+        {
+            var path = kv.Key;
+            var change = kv.Value;
+            switch (change.Kind)
+            {
+                case "add":
+                case "delete":
+                    if (!IsWritable(path))
+                        return false;
+                    break;
+                case "update":
+                    if (!IsWritable(path))
+                        return false;
+                    if (change.MovePath != null && !IsWritable(change.MovePath))
+                        return false;
+                    break;
+            }
+        }
+
+        return true;
     }
 
     public static SafetyCheck AssessCommandSafety(List<string> command, ApprovalMode policy, SandboxPolicy sandbox, HashSet<List<string>> approved)
@@ -50,6 +89,6 @@ public static class Safety
         return SafetyCheck.AskUser;
     }
 
-    private static bool IsPathWritable(string path, List<string> roots)
-        => roots.Count == 0 || roots.Any(r => Path.GetFullPath(path).StartsWith(Path.GetFullPath(r)));
+    // Helpers for earlier versions retained for completeness, though not used
+    // in current ports.
 }

--- a/codex-dotnet/CodexCli/prompt.md
+++ b/codex-dotnet/CodexCli/prompt.md
@@ -1,0 +1,98 @@
+Please resolve the user's task by editing and testing the code files in your current code execution session.
+You are a deployed coding agent.
+Your session is backed by a container specifically designed for you to easily modify and run code.
+The repo(s) are already cloned in your working directory, and you must fully solve the problem for your answer to be considered correct.
+
+You MUST adhere to the following criteria when executing the task:
+
+- Working on the repo(s) in the current environment is allowed, even if they are proprietary.
+- Analyzing code for vulnerabilities is allowed.
+- Showing user code and tool call details is allowed.
+- User instructions may overwrite the _CODING GUIDELINES_ section in this developer message.
+- Do not use \`ls -R\`, \`find\`, or \`grep\` - these are slow in large repos. Use \`rg\` and \`rg --files\`.
+- Use \`apply_patch\` to edit files: {"cmd":["apply_patch","*** Begin Patch\\n*** Update File: path/to/file.py\\n@@ def example():\\n- pass\\n+ return 123\\n*** End Patch"]}
+- If completing the user's task requires writing or modifying files:
+  - Your code and final answer should follow these _CODING GUIDELINES_:
+    - Fix the problem at the root cause rather than applying surface-level patches, when possible.
+    - Avoid unneeded complexity in your solution.
+      - Ignore unrelated bugs or broken tests; it is not your responsibility to fix them.
+    - Update documentation as necessary.
+    - Keep changes consistent with the style of the existing codebase. Changes should be minimal and focused on the task.
+      - Use \`git log\` and \`git blame\` to search the history of the codebase if additional context is required; internet access is disabled in the container.
+    - NEVER add copyright or license headers unless specifically requested.
+    - You do not need to \`git commit\` your changes; this will be done automatically for you.
+    - If there is a .pre-commit-config.yaml, use \`pre-commit run --files ...\` to check that your changes pass the pre- commit checks. However, do not fix pre-existing errors on lines you didn't touch.
+      - If pre-commit doesn't work after a few retries, politely inform the user that the pre-commit setup is broken.
+    - Once you finish coding, you must
+      - Check \`git status\` to sanity check your changes; revert any scratch files or changes.
+      - Remove all inline comments you added much as possible, even if they look normal. Check using \`git diff\`. Inline comments must be generally avoided, unless active maintainers of the repo, after long careful study of the code and the issue, will still misinterpret the code without the comments.
+      - Check if you accidentally add copyright or license headers. If so, remove them.
+      - Try to run pre-commit if it is available.
+      - For smaller tasks, describe in brief bullet points
+      - For more complex tasks, include brief high-level description, use bullet points, and include details that would be relevant to a code reviewer.
+- If completing the user's task DOES NOT require writing or modifying files (e.g., the user asks a question about the code base):
+  - Respond in a friendly tune as a remote teammate, who is knowledgeable, capable and eager to help with coding.
+- When your task involves writing or modifying files:
+  - Do NOT tell the user to "save the file" or "copy the code into a file" if you already created or modified the file using \`apply_patch\`. Instead, reference the file as already saved.
+  - Do NOT show the full contents of large files you have already written, unless the user explicitly asks for them.
+
+§ `apply-patch` Specification
+
+Your patch language is a stripped‑down, file‑oriented diff format designed to be easy to parse and safe to apply. You can think of it as a high‑level envelope:
+
+**_ Begin Patch
+[ one or more file sections ]
+_** End Patch
+
+Within that envelope, you get a sequence of file operations.
+You MUST include a header to specify the action you are taking.
+Each operation starts with one of three headers:
+
+**_ Add File: <path> - create a new file. Every following line is a + line (the initial contents).
+_** Delete File: <path> - remove an existing file. Nothing follows.
+\*\*\* Update File: <path> - patch an existing file in place (optionally with a rename).
+
+May be immediately followed by \*\*\* Move to: <new path> if you want to rename the file.
+Then one or more “hunks”, each introduced by @@ (optionally followed by a hunk header).
+Within a hunk each line starts with:
+
+- for inserted text,
+
+* for removed text, or
+  space ( ) for context.
+  At the end of a truncated hunk you can emit \*\*\* End of File.
+
+Patch := Begin { FileOp } End
+Begin := "**_ Begin Patch" NEWLINE
+End := "_** End Patch" NEWLINE
+FileOp := AddFile | DeleteFile | UpdateFile
+AddFile := "**_ Add File: " path NEWLINE { "+" line NEWLINE }
+DeleteFile := "_** Delete File: " path NEWLINE
+UpdateFile := "**_ Update File: " path NEWLINE [ MoveTo ] { Hunk }
+MoveTo := "_** Move to: " newPath NEWLINE
+Hunk := "@@" [ header ] NEWLINE { HunkLine } [ "*** End of File" NEWLINE ]
+HunkLine := (" " | "-" | "+") text NEWLINE
+
+A full patch can combine several operations:
+
+**_ Begin Patch
+_** Add File: hello.txt
++Hello world
+**_ Update File: src/app.py
+_** Move to: src/main.py
+@@ def greet():
+-print("Hi")
++print("Hello, world!")
+**_ Delete File: obsolete.txt
+_** End Patch
+
+It is important to remember:
+
+- You must include a header with your intended action (Add/Delete/Update)
+- You must prefix new lines with `+` even when creating a new file
+
+You can invoke apply_patch like:
+
+```
+shell {"command":["apply_patch","*** Begin Patch\n*** Add File: hello.txt\n+Hello, world!\n*** End Patch\n"]}
+```

--- a/codex-dotnet/CodexCli/prompt.md
+++ b/codex-dotnet/CodexCli/prompt.md
@@ -1,3 +1,4 @@
+<!-- Source: codex-rs/core/prompt.md -->
 Please resolve the user's task by editing and testing the code files in your current code execution session.
 You are a deployed coding agent.
 Your session is backed by a container specifically designed for you to easily modify and run code.

--- a/codex-rs/apply-patch/apply_patch_tool_instructions.md
+++ b/codex-rs/apply-patch/apply_patch_tool_instructions.md
@@ -1,3 +1,4 @@
+<!-- C# port: codex-dotnet/CodexCli/ApplyPatch/apply_patch_tool_instructions.md (done) -->
 To edit files, ALWAYS use the `shell` tool with `apply_patch` CLI.  `apply_patch` effectively allows you to execute a diff/patch against a file, but the format of the diff specification is unique to this task, so pay careful attention to these instructions. To use the `apply_patch` CLI, you should call the shell tool with the following structure:
 
 ```bash

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -57,6 +57,7 @@ impl PartialEq for IoError {
 }
 
 #[derive(Debug, PartialEq)]
+// C# port in codex-dotnet/CodexCli/ApplyPatch/ApplyPatchCommandParser.cs MaybeParseApplyPatch and MaybeParseApplyPatchVerified (done)
 pub enum MaybeApplyPatch {
     Body(Vec<Hunk>),
     ShellParseError(ExtractHeredocError),
@@ -209,6 +210,7 @@ pub fn maybe_parse_apply_patch_verified(argv: &[String], cwd: &Path) -> MaybeApp
 /// * `Ok(String)` - The heredoc body if the extraction is successful.
 /// * `Err(anyhow::Error)` - An error if the extraction fails.
 ///
+// C# port in codex-dotnet/CodexCli/ApplyPatch/ApplyPatchCommandParser.cs ExtractHeredocBodyFromApplyPatchCommand (done)
 fn extract_heredoc_body_from_apply_patch_command(
     src: &str,
 ) -> std::result::Result<String, ExtractHeredocError> {
@@ -258,6 +260,7 @@ pub enum ExtractHeredocError {
 }
 
 /// Applies the patch and prints the result to stdout/stderr.
+// C# port in codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAndReport (done)
 pub fn apply_patch(
     patch: &str,
     stdout: &mut impl std::io::Write,

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -604,6 +604,7 @@ pub fn unified_diff_from_chunks_with_context(
 }
 
 /// Print the summary of changes in git-style format.
+/// C# port in codex-dotnet/CodexCli/ApplyPatch/PatchSummary.cs PrintSummary (done)
 /// Write a summary of changes to the given writer.
 pub fn print_summary(
     affected: &AffectedPaths,

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -20,6 +20,7 @@ use tree_sitter::Parser;
 use tree_sitter_bash::LANGUAGE as BASH;
 
 /// Detailed instructions for gpt-4.1 on how to use the `apply_patch` tool.
+/// C# port embedded as CodexCli/ApplyPatch/apply_patch_tool_instructions.md (done)
 pub const APPLY_PATCH_TOOL_INSTRUCTIONS: &str = include_str!("../apply_patch_tool_instructions.md");
 
 #[derive(Debug, Error, PartialEq)]

--- a/codex-rs/core/prompt.md
+++ b/codex-rs/core/prompt.md
@@ -1,3 +1,4 @@
+<!-- C# port: codex-dotnet/CodexCli/prompt.md (done) -->
 Please resolve the user's task by editing and testing the code files in your current code execution session.
 You are a deployed coding agent.
 Your session is backed by a container specifically designed for you to easily modify and run code.

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -15,6 +15,7 @@ use tokio::sync::mpsc;
 
 /// The `instructions` field in the payload sent to a model should always start
 /// with this content.
+// C# port embedded as CodexCli/prompt.md (done)
 const BASE_INSTRUCTIONS: &str = include_str!("../prompt.md");
 
 /// API request payload for a single model turn.

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -379,6 +379,7 @@ impl Session {
     }
 
     /// Returns the input if there was no task running to inject into
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs InjectInput (done)
     pub fn inject_input(&self, input: Vec<InputItem>) -> Result<(), Vec<InputItem>> {
         let mut state = self.state.lock().unwrap();
         if state.current_task.is_some() {
@@ -389,6 +390,7 @@ impl Session {
         }
     }
 
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs GetPendingInput (done)
     pub fn get_pending_input(&self) -> Vec<ResponseInputItem> {
         let mut state = self.state.lock().unwrap();
         if state.pending_input.is_empty() {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1219,6 +1219,7 @@ async fn handle_function_call(
     }
 }
 
+// C# port in codex-dotnet/CodexCli/Util/Codex.cs ToExecParams (done)
 fn to_exec_params(params: ShellToolCallParams, sess: &Session) -> ExecParams {
     ExecParams {
         command: params.command,
@@ -1228,6 +1229,7 @@ fn to_exec_params(params: ShellToolCallParams, sess: &Session) -> ExecParams {
     }
 }
 
+// C# port in codex-dotnet/CodexCli/Util/Codex.cs ParseContainerExecArguments (done)
 fn parse_container_exec_arguments(
     arguments: String,
     sess: &Session,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1774,6 +1774,7 @@ fn convert_apply_patch_to_protocol(action: &ApplyPatchAction) -> HashMap<PathBuf
     result
 }
 
+// C# port in codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyActionAndReport (done)
 fn apply_changes_from_apply_patch_and_report(
     action: &ApplyPatchAction,
     stdout: &mut impl std::io::Write,
@@ -1791,6 +1792,7 @@ fn apply_changes_from_apply_patch_and_report(
     Ok(())
 }
 
+// C# port in codex-dotnet/CodexCli/ApplyPatch/PatchApplier.cs ApplyAction (done)
 fn apply_changes_from_apply_patch(action: &ApplyPatchAction) -> anyhow::Result<AffectedPaths> {
     let mut added: Vec<PathBuf> = Vec::new();
     let mut modified: Vec<PathBuf> = Vec::new();

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -456,6 +456,7 @@ impl Drop for Session {
 }
 
 impl State {
+    // C# port in codex-dotnet/CodexCli/Util/CodexState.cs PartialClone (done)
     pub fn partial_clone(&self, retain_zdr_transcript: bool) -> Self {
         Self {
             approved_commands: self.approved_commands.clone(),

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -242,6 +242,7 @@ impl Session {
         }
     }
 
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs RequestCommandApproval (done)
     pub async fn request_command_approval(
         &self,
         sub_id: String,
@@ -266,6 +267,7 @@ impl Session {
         rx_approve
     }
 
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs RequestPatchApproval (done)
     pub async fn request_patch_approval(
         &self,
         sub_id: String,
@@ -290,6 +292,7 @@ impl Session {
         rx_approve
     }
 
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs NotifyApproval (done)
     pub fn notify_approval(&self, sub_id: &str, decision: ReviewDecision) {
         let mut state = self.state.lock().unwrap();
         if let Some(tx_approve) = state.pending_approvals.remove(sub_id) {
@@ -297,6 +300,7 @@ impl Session {
         }
     }
 
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs AddApprovedCommand (done)
     pub fn add_approved_command(&self, cmd: Vec<String>) {
         let mut state = self.state.lock().unwrap();
         state.approved_commands.insert(cmd);

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1851,6 +1851,7 @@ fn apply_changes_from_apply_patch(action: &ApplyPatchAction) -> anyhow::Result<A
     })
 }
 
+// C# port in codex-dotnet/CodexCli/Util/Codex.cs GetWritableRoots (done)
 fn get_writable_roots(cwd: &Path) -> Vec<std::path::PathBuf> {
     let mut writable_roots = Vec::new();
     if cfg!(target_os = "macos") {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -422,6 +422,7 @@ impl Session {
     /// Spawn the configured notifier (if any) with the given JSON payload as
     /// the last argument. Failures are logged but otherwise ignored so that
     /// notification issues do not interfere with the main workflow.
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs MaybeNotify (done)
     fn maybe_notify(&self, notification: UserNotification) {
         let Some(notify_command) = &self.notify else {
             return;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1909,6 +1909,7 @@ fn format_exec_output(output: &str, exit_code: i32, duration: std::time::Duratio
     serde_json::to_string(&payload).expect("serialize ExecOutput")
 }
 
+// C# port in codex-dotnet/CodexCli/Util/Codex.cs GetLastAssistantMessageFromTurn (done)
 fn get_last_assistant_message_from_turn(responses: &[ResponseItem]) -> Option<String> {
     responses.iter().rev().find_map(|item| {
         if let ResponseItem::Message { role, content } = item {
@@ -1930,6 +1931,7 @@ fn get_last_assistant_message_from_turn(responses: &[ResponseItem]) -> Option<St
 }
 
 /// See [`ConversationHistory`] for details.
+// C# port in codex-dotnet/CodexCli/Util/Codex.cs RecordConversationHistory (done)
 fn record_conversation_history(disable_response_storage: bool, wire_api: WireApi) -> bool {
     if disable_response_storage {
         return true;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -195,6 +195,7 @@ pub(crate) struct Session {
 }
 
 impl Session {
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs ResolvePath (done)
     fn resolve_path(&self, path: Option<String>) -> PathBuf {
         path.as_ref()
             .map(PathBuf::from)

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -215,6 +215,7 @@ struct State {
 }
 
 impl Session {
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs SetTask (done)
     pub fn set_task(&self, task: AgentTask) {
         let mut state = self.state.lock().unwrap();
         if let Some(current_task) = state.current_task.take() {
@@ -223,6 +224,7 @@ impl Session {
         state.current_task = Some(task);
     }
 
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs RemoveTask (done)
     pub fn remove_task(&self, sub_id: &str) {
         let mut state = self.state.lock().unwrap();
         if let Some(task) = &state.current_task {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1749,6 +1749,7 @@ fn first_offending_path(
     None
 }
 
+// C# port in codex-dotnet/CodexCli/Util/Codex.cs ConvertApplyPatchToProtocol (done)
 fn convert_apply_patch_to_protocol(action: &ApplyPatchAction) -> HashMap<PathBuf, FileChange> {
     let changes = action.changes();
     let mut result = HashMap::with_capacity(changes.len());

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -327,6 +327,7 @@ impl Session {
         }
     }
 
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs NotifyExecCommandBegin (done)
     async fn notify_exec_command_begin(&self, sub_id: &str, call_id: &str, params: &ExecParams) {
         let event = Event {
             id: sub_id.to_string(),
@@ -339,6 +340,7 @@ impl Session {
         let _ = self.tx_event.send(event).await;
     }
 
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs NotifyExecCommandEnd (done)
     async fn notify_exec_command_end(
         &self,
         sub_id: &str,
@@ -365,6 +367,7 @@ impl Session {
     /// Helper that emits a BackgroundEvent with the given message. This keeps
     /// the call‑sites terse so adding more diagnostics does not clutter the
     /// core agent logic.
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs NotifyBackgroundEvent (done)
     async fn notify_background_event(&self, sub_id: &str, message: impl Into<String>) {
         let event = Event {
             id: sub_id.to_string(),

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1710,6 +1710,7 @@ async fn apply_patch(
 /// Return the first path in `hunks` that is NOT under any of the
 /// `writable_roots` (after normalising). If all paths are acceptable,
 /// returns None.
+// C# port in codex-dotnet/CodexCli/Util/Codex.cs FirstOffendingPath (done)
 fn first_offending_path(
     action: &ApplyPatchAction,
     writable_roots: &[PathBuf],

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1878,6 +1878,7 @@ fn get_writable_roots(cwd: &Path) -> Vec<std::path::PathBuf> {
     writable_roots
 }
 
+// C# port in codex-dotnet/CodexCli/Util/Codex.cs FormatExecOutput (done)
 /// Exec output is a pre-serialized JSON payload
 fn format_exec_output(output: &str, exit_code: i32, duration: std::time::Duration) -> String {
     #[derive(Serialize)]

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -302,6 +302,7 @@ impl Session {
         state.approved_commands.insert(cmd);
     }
 
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs RecordConversationItemsAsync (done)
     /// Records items to both the rollout and the chat completions/ZDR
     /// transcript, if enabled.
     async fn record_conversation_items(&self, items: &[ResponseItem]) {
@@ -313,6 +314,7 @@ impl Session {
         }
     }
 
+    // C# port in codex-dotnet/CodexCli/Util/Codex.cs RecordRolloutItemsAsync (done)
     /// Append the given items to the session's rollout transcript (if enabled)
     /// and persist them to disk.
     async fn record_rollout_items(&self, items: &[ResponseItem]) {

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -64,6 +64,7 @@ pub struct ExecParams {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+// C# port in codex-dotnet/CodexCli/Protocol/SandboxType.cs (done)
 pub enum SandboxType {
     None,
 

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -114,6 +114,7 @@ pub fn get_platform_sandbox() -> Option<SandboxType> {
     }
 }
 
+// C# port in codex-dotnet/CodexCli/Util/Safety.cs IsWritePatchConstrainedToWritableRoots (done)
 fn is_write_patch_constrained_to_writable_paths(
     action: &ApplyPatchAction,
     writable_roots: &[PathBuf],

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -104,6 +104,7 @@ pub fn assess_command_safety(
     }
 }
 
+// C# port in codex-dotnet/CodexCli/Util/Safety.cs GetPlatformSandbox (done)
 pub fn get_platform_sandbox() -> Option<SandboxType> {
     if cfg!(target_os = "macos") {
         Some(SandboxType::MacosSeatbelt)


### PR DESCRIPTION
## Summary
- port `format_exec_output` from codex-rs into `Codex.FormatExecOutput`
- mark both Rust and C# sources with migration comments
- document the new mapping and progress in `AGENTS.md`
- add unit test verifying JSON output

## Testing
- `pnpm test` *(fails: Process with PID ... failed to terminate)*
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6857cbe44d8c83298c318dd551659812